### PR TITLE
Define package dependencies across the project with workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,20 @@ license    = "MIT"
 homepage   = "https://github.com/t28hub/auto-palette"
 repository = "https://github.com/t28hub/auto-palette"
 
+[workspace.dependencies]
+auto-palette             = { version = "0.2.0", path = "./crates/core" }
+getrandom                = "0.2.15"
+image                    = "0.25.1"
+num-traits               = "0.2.18"
+rand                     = { version = "0.8.5", default-features = false, features = ["std_rng"] }
+rand_distr               = "0.4.3"
+reqwest                  = { version = "0.12.4", features = ["blocking"] }
+rstest                   = "0.19.0"
+wasm-bindgen-test        = "0.3.42"
+console_error_panic_hook = "0.1.7"
+js-sys                   = "0.3.69"
+wasm-bindgen             = "0.2.92"
+
 [profile.dev]
 opt-level = 3
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,15 +20,15 @@ image   = ["dep:image"]
 wasm    = ["getrandom/js"]
 
 [dependencies]
-getrandom  = { version = "0.2.3", default-features = false }
-image      = { version = "0.25.1", optional = true }
-num-traits = "0.2.18"
-rand       = { version = "0.8.5", default-features = false, features = ["std_rng"] }
-rand_distr = "0.4.3"
+getrandom  = { workspace = true }
+image      = { workspace = true, optional = true }
+num-traits = { workspace = true }
+rand       = { workspace = true }
+rand_distr = { workspace = true }
 
 [dev-dependencies]
-reqwest = { version = "0.12.4", features = ["blocking"] }
-rstest  = "0.19.0"
+reqwest = { workspace = true }
+rstest  = { workspace = true }
 
 [[example]]
 name              = "basic"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -18,12 +18,12 @@ rust-version = "1.75.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-auto-palette             = { path = "../core", features = ["wasm"] }
-console_error_panic_hook = "0.1.7"
-js-sys                   = "0.3.69"
-wasm-bindgen             = "0.2.92"
+auto-palette             = { workspace = true, features = ["wasm"] }
+console_error_panic_hook = { workspace = true }
+js-sys                   = { workspace = true }
+wasm-bindgen             = { workspace = true }
 
 [dev-dependencies]
-image             = "0.25.1"
-rstest            = "0.19.0"
-wasm-bindgen-test = "0.3.42"
+image             = { workspace = true }
+rstest            = { workspace = true }
+wasm-bindgen-test = { workspace = true }


### PR DESCRIPTION
## Description

In this pull request, the package dependencies are defined in `workspace.dependencies` to share the package dependencies across the project.

## Related Issue

No related issue.

## Type of Change

- [x] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
