### PR TITLE
Add D50 white point and color conversion methods in Color struct

### DIFF
--- a/crates/auto-palette-wasm/src/color/mod.rs
+++ b/crates/auto-palette-wasm/src/color/mod.rs
@@ -60,7 +60,7 @@ impl ColorWrapper {
     /// # Returns
     /// The hue of this color.
     pub fn hue(&self) -> f32 {
-        self.0.hue()
+        self.0.hue().value()
     }
 
     /// Returns the RGB representation of this color.
@@ -181,7 +181,7 @@ mod tests {
         let actual = wrapper.hue();
 
         // Assert
-        assert_eq!(actual, color.hue());
+        assert_eq!(actual, color.hue().value());
     }
 
     #[wasm_bindgen_test]

--- a/crates/auto-palette/src/color/luv.rs
+++ b/crates/auto-palette/src/color/luv.rs
@@ -113,18 +113,10 @@ where
 
         let denominator =
             W::x::<T>() + T::from_f32(15.0) * W::y::<T>() + T::from_f32(3.0) * W::z::<T>();
-        let u_prime_div = if denominator.is_zero() {
-            T::zero()
-        } else {
-            T::from_f32(4.0) * W::x() / denominator
-        };
-        let v_prime_ref = if denominator.is_zero() {
-            T::zero()
-        } else {
-            T::from_f32(9.0) * W::y() / denominator
-        };
+        let u_prime_ref = T::from_f32(4.0) * W::x() / denominator;
+        let v_prime_ref = T::from_f32(9.0) * W::y() / denominator;
 
-        let u = T::from_f32(13.0) * l * (u_prime - u_prime_div);
+        let u = T::from_f32(13.0) * l * (u_prime - u_prime_ref);
         let v = T::from_f32(13.0) * l * (v_prime - v_prime_ref);
         Luv::new(l, u, v)
     }

--- a/crates/auto-palette/src/color/white_point.rs
+++ b/crates/auto-palette/src/color/white_point.rs
@@ -2,11 +2,11 @@ use std::fmt::Debug;
 
 use crate::math::FloatNumber;
 
-/// White point trait representation.
+/// White point representation.
 ///
 /// # References
 /// * [White point - Wikipedia](https://en.wikipedia.org/wiki/White_point)
-pub trait WhitePoint: Debug + Default + PartialEq {
+pub trait WhitePoint: Copy + Clone + Debug + Default + PartialEq {
     /// Returns the X component of the white point.
     ///
     /// # Type Parameters
@@ -44,11 +44,44 @@ pub trait WhitePoint: Debug + Default + PartialEq {
         T: FloatNumber;
 }
 
-/// Struct representing CIE standard illuminant D65.
+/// The D50 white point representation.
+///
+/// # References
+/// * [Illuminant D50](https://en.wikipedia.org/wiki/Illuminant_D50)
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct D50;
+
+impl WhitePoint for D50 {
+    #[inline]
+    fn x<T>() -> T
+    where
+        T: FloatNumber,
+    {
+        T::from_f32(0.964_22)
+    }
+
+    #[inline]
+    fn y<T>() -> T
+    where
+        T: FloatNumber,
+    {
+        T::from_f32(1.0)
+    }
+
+    #[inline]
+    fn z<T>() -> T
+    where
+        T: FloatNumber,
+    {
+        T::from_f32(0.825_21)
+    }
+}
+
+/// The D65 white point representation.
 ///
 /// # References
 /// * [Illuminant D65](https://en.wikipedia.org/wiki/Illuminant_D65)
-#[derive(Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct D65;
 
 impl WhitePoint for D65 {
@@ -80,6 +113,18 @@ impl WhitePoint for D65 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_d50() {
+        let x: f32 = D50::x();
+        assert_eq!(x, 0.964_22);
+
+        let y: f32 = D50::y();
+        assert_eq!(y, 1.0);
+
+        let z: f32 = D50::z();
+        assert_eq!(z, 0.825_21);
+    }
 
     #[test]
     fn test_d65() {

--- a/crates/auto-palette/src/palette.rs
+++ b/crates/auto-palette/src/palette.rs
@@ -208,9 +208,9 @@ where
                 let x = T::from_usize(index % width);
                 let y = T::from_usize(index / width);
                 Some([
-                    normalize(l, Lab::min_l(), Lab::max_l()),
-                    normalize(a, Lab::min_a(), Lab::max_a()),
-                    normalize(b, Lab::min_b(), Lab::max_b()),
+                    normalize(l, Lab::<T>::min_l(), Lab::<T>::max_l()),
+                    normalize(a, Lab::<T>::min_a(), Lab::<T>::max_a()),
+                    normalize(b, Lab::<T>::min_b(), Lab::<T>::max_b()),
                     normalize(x, T::zero(), width_f),
                     normalize(y, T::zero(), height_f),
                 ])
@@ -230,9 +230,9 @@ where
         .map(|cluster| -> Point<T, 3> {
             let centroid = cluster.centroid();
             [
-                denormalize(centroid[0], Lab::min_l(), Lab::max_l()),
-                denormalize(centroid[1], Lab::min_a(), Lab::max_a()),
-                denormalize(centroid[2], Lab::min_b(), Lab::max_b()),
+                denormalize(centroid[0], Lab::<T>::min_l(), Lab::<T>::max_l()),
+                denormalize(centroid[1], Lab::<T>::min_a(), Lab::<T>::max_a()),
+                denormalize(centroid[2], Lab::<T>::min_b(), Lab::<T>::max_b()),
             ]
         })
         .collect::<Vec<_>>();
@@ -281,9 +281,9 @@ where
                 total_population += pixel_cluster.len();
             }
 
-            let l = denormalize(best_color[0], Lab::min_l(), Lab::max_l());
-            let a = denormalize(best_color[1], Lab::min_a(), Lab::max_a());
-            let b = denormalize(best_color[2], Lab::min_b(), Lab::max_b());
+            let l = denormalize(best_color[0], Lab::<T>::min_l(), Lab::<T>::max_l());
+            let a = denormalize(best_color[1], Lab::<T>::min_a(), Lab::<T>::max_a());
+            let b = denormalize(best_color[2], Lab::<T>::min_b(), Lab::<T>::max_b());
             acc.push(Swatch::new(
                 Color::new(l, a, b),
                 best_position,


### PR DESCRIPTION
## Description

In this pull request, I have added support for the `D50` white point and enabled the specification of any white point in the CIE L*a*b* color space.  
Additionally, I have implemented methods to convert the Color struct to colors in other color spaces (HSL, HSV, CIE L*u*v*).

## Related Issue

No related issue.

## Type of Change

- [x] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
