### PR TITLE
Add LCH(ab) and LCH(uv) color spaces and their conversion with CIE L*a*b* and CIE L*u*v*

### DIFF
--- a/crates/auto-palette/src/color/hsl.rs
+++ b/crates/auto-palette/src/color/hsl.rs
@@ -51,7 +51,7 @@ where
     #[must_use]
     pub fn new(h: T, s: T, l: T) -> Self {
         Self {
-            h: Hue::from(h),
+            h: Hue::from_degrees(h),
             s: clamp(s, T::zero(), T::one()),
             l: clamp(l, T::zero(), T::one()),
         }
@@ -116,7 +116,7 @@ mod tests {
         assert_eq!(
             actual,
             HSL {
-                h: Hue::from(60.0),
+                h: Hue::from_degrees(60.0),
                 s: 1.0,
                 l: 0.5,
             }

--- a/crates/auto-palette/src/color/hsv.rs
+++ b/crates/auto-palette/src/color/hsv.rs
@@ -51,7 +51,7 @@ where
     #[must_use]
     pub fn new(h: T, s: T, v: T) -> Self {
         Self {
-            h: Hue::from(h),
+            h: Hue::from_degrees(h),
             s: clamp(s, T::zero(), T::one()),
             v: clamp(v, T::zero(), T::one()),
         }
@@ -119,7 +119,7 @@ mod tests {
         assert_eq!(
             actual,
             HSV {
-                h: Hue::from(60.0),
+                h: Hue::from_degrees(60.0),
                 s: 1.0,
                 v: 1.0
             }

--- a/crates/auto-palette/src/color/hue.rs
+++ b/crates/auto-palette/src/color/hue.rs
@@ -11,7 +11,7 @@ use crate::math::FloatNumber;
 /// ```
 /// use auto_palette::color::Hue;
 ///
-/// let hue = Hue::from(485.0);
+/// let hue = Hue::from_degrees(485.0);
 /// assert_eq!(hue.value(), 125.0);
 /// assert_eq!(format!("{}", hue), "125.00");
 /// ```
@@ -32,14 +32,10 @@ where
     pub fn value(self) -> T {
         self.0
     }
-}
 
-impl<T> From<T> for Hue<T>
-where
-    T: FloatNumber,
-{
-    fn from(value: T) -> Self {
-        Self(normalize(value))
+    #[must_use]
+    pub fn from_degrees(degrees: T) -> Self {
+        Self(normalize(degrees))
     }
 }
 
@@ -72,27 +68,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_from() {
+    fn test_from_degrees() {
         // Act
-        let degree = Hue::from(720.0);
+        let degree = Hue::from_degrees(720.0);
 
         // Assert
         assert_eq!(degree.value(), 0.0);
     }
 
     #[test]
-    fn test_from_negative() {
+    fn test_from_degrees_negative() {
         // Act
-        let degree = Hue::from(-90.0);
+        let degree = Hue::from_degrees(-90.0);
 
         // Assert
         assert_eq!(degree.value(), 270.0);
     }
 
     #[test]
-    fn test_from_overflow() {
+    fn test_from_degrees_overflow() {
         // Act
-        let degree = Hue::from(360.0);
+        let degree = Hue::from_degrees(360.0);
 
         // Assert
         assert_eq!(degree.value(), 0.0);
@@ -101,7 +97,7 @@ mod tests {
     #[test]
     fn test_fmt() {
         // Act
-        let degree = Hue::from(45.0);
+        let degree = Hue::from_degrees(45.0);
         let actual = format!("{}", degree);
 
         // Assert

--- a/crates/auto-palette/src/color/lchab.rs
+++ b/crates/auto-palette/src/color/lchab.rs
@@ -1,0 +1,144 @@
+use std::{fmt::Display, marker::PhantomData};
+
+use num_traits::clamp;
+
+use crate::{
+    color::{Hue, Lab, WhitePoint, D65},
+    math::FloatNumber,
+};
+
+/// CIE LCH(ab) color space representation.
+///
+/// See the following for more details:
+/// [CIE LAB | Cylindrical model](https://en.wikipedia.org/wiki/CIELAB_color_space#Cylindrical_model)
+///
+/// # Type Parameters
+/// * `T` - The floating point type.
+/// * `W` - The white point type.
+///
+/// # Fields
+/// * `l` - The lightness component.
+/// * `c` - The chroma component.
+/// * `h` - The hue component.
+///
+/// # Examples
+/// ```
+/// use auto_palette::color::{LCHab, Lab, D65};
+///
+/// let lchab: LCHab<_> = LCHab::new(54.617, 92.151, 27.756);
+/// assert_eq!(format!("{}", lchab), "LCH(ab)(54.62, 92.15, 27.76)");
+///
+/// let lab: Lab<_> = (&lchab).into();
+/// assert_eq!(format!("{}", lab), "Lab(54.62, 81.55, 42.92)");
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct LCHab<T, W = D65>
+where
+    T: FloatNumber,
+    W: WhitePoint,
+{
+    pub l: T,
+    pub c: T,
+    pub h: Hue<T>,
+    _marker: PhantomData<W>,
+}
+
+impl<T, W> LCHab<T, W>
+where
+    T: FloatNumber,
+    W: WhitePoint,
+{
+    /// Creates a new `LCHab` instance.
+    ///
+    /// # Arguments
+    /// * `l` - The lightness component.
+    /// * `c` - The chroma component.
+    /// * `h` - The hue component.
+    ///
+    /// # Returns
+    /// A new `LCHab` instance.
+    #[must_use]
+    pub fn new(l: T, c: T, h: T) -> Self {
+        Self {
+            l: clamp(l, T::zero(), T::from_u32(100)),
+            c: clamp(c, T::zero(), T::from_u32(180)),
+            h: Hue::from_degrees(h),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, W> Display for LCHab<T, W>
+where
+    T: FloatNumber,
+    W: WhitePoint,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LCH(ab)({:.2}, {:.2}, {:.2})",
+            self.l,
+            self.c,
+            self.h.value()
+        )
+    }
+}
+
+impl<T, W> From<&Lab<T, W>> for LCHab<T, W>
+where
+    T: FloatNumber,
+    W: WhitePoint,
+{
+    fn from(lab: &Lab<T, W>) -> Self {
+        // This implementation is based on the formulae from the following sources:
+        // http://www.brucelindbloom.com/index.html?Eqn_Lab_to_LCH.html
+        let l = lab.l;
+        let c = (lab.a.powi(2) + lab.b.powi(2)).sqrt();
+        let h = lab.b.atan2(lab.a).to_degrees();
+        Self::new(l, c, h)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        // Act
+        let actual = LCHab::<_>::new(54.617, 92.151, 27.756);
+
+        // Assert
+        assert_eq!(
+            actual,
+            LCHab {
+                l: 54.617,
+                c: 92.151,
+                h: Hue::from_degrees(27.756),
+                _marker: PhantomData,
+            }
+        );
+    }
+
+    #[test]
+    fn test_fmt() {
+        // Act
+        let lchab = LCHab::<f32>::new(54.617, 92.151, 27.756);
+        let actual = format!("{}", lchab);
+
+        // Assert
+        assert_eq!(actual, "LCH(ab)(54.62, 92.15, 27.76)");
+    }
+
+    #[test]
+    fn test_from_lab() {
+        // Arrange
+        let lab: Lab<f32> = Lab::new(54.617, 81.549, 42.915);
+        let actual = LCHab::from(&lab);
+
+        // Assert
+        assert_eq!(actual.l, 54.617);
+        assert!((actual.c - 92.151).abs() < 1e-3);
+        assert!((actual.h.value() - 27.756).abs() < 1e-3);
+    }
+}

--- a/crates/auto-palette/src/color/lchuv.rs
+++ b/crates/auto-palette/src/color/lchuv.rs
@@ -1,0 +1,145 @@
+use std::{fmt::Display, marker::PhantomData};
+
+use num_traits::clamp;
+
+use crate::{
+    color::{Hue, Luv, WhitePoint, D65},
+    math::FloatNumber,
+};
+
+/// CIE LCH(uv) color space representation.
+///
+/// See the following for more details:
+/// [CIE LUV | Cylindrical representation (CIELCh)](https://en.wikipedia.org/wiki/CIELUV#Cylindrical_representation_(CIELCh))
+///
+/// # Type Parameters
+/// * `T` - The floating point type.
+/// * `W` - The white point type.
+///
+/// # Fields
+/// * `l` - The lightness component.
+/// * `c` - The chroma component.
+/// * `h` - The hue component.
+///
+/// # Examples
+/// ```
+/// use auto_palette::color::{LCHuv, Luv, D65};
+///
+/// let lchuv: LCHuv<_> = LCHuv::new(56.232, 50.875, 154.710);
+/// assert_eq!(format!("{}", lchuv), "LCH(uv)(56.23, 50.88, 154.71)");
+///
+/// let luv: Luv<_> = (&lchuv).into();
+/// assert_eq!(format!("{}", luv), "Luv(56.23, -46.00, 21.73)");
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct LCHuv<T, W = D65>
+where
+    T: FloatNumber,
+    W: WhitePoint,
+{
+    pub l: T,
+    pub c: T,
+    pub h: Hue<T>,
+    _marker: PhantomData<W>,
+}
+
+impl<T, W> LCHuv<T, W>
+where
+    T: FloatNumber,
+    W: WhitePoint,
+{
+    /// Creates a new `LCHuv` instance.
+    ///
+    /// # Arguments
+    /// * `l` - The lightness component.
+    /// * `c` - The chroma component.
+    /// * `h` - The hue component.
+    ///
+    /// # Returns
+    /// A new `LCHuv` instance.
+    #[must_use]
+    pub fn new(l: T, c: T, h: T) -> Self {
+        Self {
+            l: clamp(l, T::zero(), T::from_u32(100)),
+            c: clamp(c, T::zero(), T::from_u32(180)),
+            h: Hue::from_degrees(h),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, W> Display for LCHuv<T, W>
+where
+    T: FloatNumber,
+    W: WhitePoint,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LCH(uv)({:.2}, {:.2}, {:.2})",
+            self.l,
+            self.c,
+            self.h.value()
+        )
+    }
+}
+
+impl<T, W> From<&Luv<T, W>> for LCHuv<T, W>
+where
+    T: FloatNumber,
+    W: WhitePoint,
+{
+    fn from(luv: &Luv<T, W>) -> Self {
+        // This implementation is based on the formulae from the following sources:
+        // http://www.brucelindbloom.com/index.html?Eqn_Luv_to_LCH.html
+        let l = luv.l;
+        let c = (luv.u * luv.u + luv.v * luv.v).sqrt();
+        let h = luv.v.atan2(luv.u).to_degrees();
+        Self::new(l, c, h)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::Luv;
+
+    #[test]
+    fn test_new() {
+        // Act
+        let actual: LCHuv<_> = LCHuv::new(56.232, 50.875, 154.710);
+
+        // Assert
+        assert_eq!(
+            actual,
+            LCHuv {
+                l: 56.232,
+                c: 50.875,
+                h: Hue::from_degrees(154.710),
+                _marker: PhantomData,
+            }
+        );
+    }
+
+    #[test]
+    fn test_fmt() {
+        // Act
+        let lchuv: LCHuv<_> = LCHuv::new(56.232, 50.875, 154.710);
+        let actual = format!("{}", lchuv);
+
+        // Assert
+        assert_eq!(actual, "LCH(uv)(56.23, 50.88, 154.71)");
+    }
+
+    #[test]
+    fn test_from_luv() {
+        // Act
+        let luv: Luv<f32> = Luv::new(56.232, -45.999, 21.734);
+        let actual = LCHuv::from(&luv);
+
+        // Assert
+        assert_eq!(actual.l, 56.232);
+        assert!((actual.c - 50.875).abs() < 1e-3);
+        assert!((actual.h.value() - 154.710).abs() < 1e-3);
+    }
+}


### PR DESCRIPTION
## Description

In this pull request, support for `LCH(uv)` and `LCH(ab)` color spaces and their conversion with `CIE L*u*v*` and `CIE L*a*b*` has been added.

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.