### PR TITLE
 Add Oklab and Oklch color spaces and their conversion with CIE XYZ

### DIFF
--- a/crates/auto-palette/src/color/lab.rs
+++ b/crates/auto-palette/src/color/lab.rs
@@ -177,9 +177,9 @@ where
         // http://www.brucelindbloom.com/index.html?Eqn_Lab_to_LCH.html
         let l = lch.l;
         let c = lch.c;
-        let h = lch.h.value();
-        let a = c * h.to_radians().cos();
-        let b = c * h.to_radians().sin();
+        let h = lch.h.value().to_radians();
+        let a = c * h.cos();
+        let b = c * h.sin();
         Lab::new(l, a, b)
     }
 }

--- a/crates/auto-palette/src/color/mod.rs
+++ b/crates/auto-palette/src/color/mod.rs
@@ -5,6 +5,8 @@ mod lab;
 mod lchab;
 mod lchuv;
 mod luv;
+mod oklab;
+mod oklch;
 mod rgb;
 mod white_point;
 mod xyz;
@@ -24,6 +26,8 @@ pub use lab::Lab;
 pub use lchab::LCHab;
 pub use lchuv::LCHuv;
 pub use luv::Luv;
+pub use oklab::Oklab;
+pub use oklch::Oklch;
 pub use rgb::RGB;
 pub use white_point::*;
 pub(crate) use xyz::rgb_to_xyz;
@@ -267,6 +271,26 @@ where
         let lab = self.to_lab();
         LCHab::<T, W>::from(&lab)
     }
+
+    /// Converts this color to the CIE Oklab color space.
+    ///
+    /// # Returns
+    /// The converted `Oklab` color.
+    #[must_use]
+    pub fn to_oklab(&self) -> Oklab<T> {
+        let xyz = self.to_xyz();
+        Oklab::from(&xyz)
+    }
+
+    /// Converts this color to the CIE Oklch color space.
+    ///
+    /// # Returns
+    /// The converted `Oklch` color.
+    #[must_use]
+    pub fn to_oklch(&self) -> Oklch<T> {
+        let oklab = self.to_oklab();
+        Oklch::from(&oklab)
+    }
 }
 
 impl<T> Display for Color<T>
@@ -481,10 +505,36 @@ mod tests {
     }
 
     #[test]
+    fn test_to_oklab() {
+        // Act
+        let color: Color<f32> = Color::new(91.1120, -48.0806, -14.1521);
+        let actual = color.to_oklab();
+
+        // Assert
+        assert!((actual.l - 0.905).abs() < 1e-3);
+        assert!((actual.a + 0.149).abs() < 1e-3);
+        assert!((actual.b + 0.040).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_to_oklch() {
+        // Act
+        let color: Color<f32> = Color::new(91.1120, -48.0806, -14.1521);
+        let actual = color.to_oklch();
+
+        // Assert
+        assert!((actual.l - 0.905).abs() < 1e-3);
+        assert!((actual.c - 0.155).abs() < 1e-3);
+        assert!((actual.h.value() - 194.82).abs() < 1e-3);
+    }
+
+    #[test]
     fn test_from_lchab() {
         // Act
         let color: Color<f32> = Color::new(91.1120, -48.0806, -14.1521);
         let actual = color.to_lchab();
+
+        println!("{:?}", actual);
 
         // Assert
         assert_eq!(actual.l, 91.1120);

--- a/crates/auto-palette/src/color/oklab.rs
+++ b/crates/auto-palette/src/color/oklab.rs
@@ -1,0 +1,176 @@
+use num_traits::clamp;
+
+use crate::{
+    color::{oklch::Oklch, XYZ},
+    math::FloatNumber,
+};
+
+/// Oklab color space representation.
+///
+/// See the following for more details:
+/// [Oklab - A perceptual color space for image processing](https://bottosson.github.io/posts/oklab/)
+///
+/// # Type Parameters
+/// * `T` - The floating point type.
+///
+/// # Fields
+/// * `l` - The lightness component.
+/// * `a` - The a component.
+/// * `b` - The b component.
+///
+/// # Examples
+/// ```
+/// use auto_palette::color::{Oklab, XYZ};
+///
+/// let oklab: Oklab<f32> = Oklab::new(0.607, -0.118, 0.028);
+/// assert_eq!(format!("{}", oklab), "Oklab(0.61, -0.12, 0.03)");
+///
+/// let xyz: XYZ<_> = (&oklab).into();
+/// assert_eq!(format!("{}", xyz), "XYZ(0.15, 0.24, 0.20)");
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct Oklab<T>
+where
+    T: FloatNumber,
+{
+    pub l: T,
+    pub a: T,
+    pub b: T,
+}
+
+impl<T> Oklab<T>
+where
+    T: FloatNumber,
+{
+    /// Creates a new `Oklab` instance.
+    ///
+    /// # Arguments
+    /// * `l` - The lightness component.
+    /// * `a` - The a component.
+    /// * `b` - The b component.
+    ///
+    /// # Returns
+    /// A new `Oklab` instance.
+    pub fn new(l: T, a: T, b: T) -> Self {
+        Self {
+            l: clamp(l, T::zero(), T::one()),
+            a,
+            b,
+        }
+    }
+}
+
+impl<T> std::fmt::Display for Oklab<T>
+where
+    T: FloatNumber,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Oklab({:.2}, {:.2}, {:.2})", self.l, self.a, self.b)
+    }
+}
+
+impl<T> From<&XYZ<T>> for Oklab<T>
+where
+    T: FloatNumber,
+{
+    fn from(xyz: &XYZ<T>) -> Self {
+        // This implementation is based on the formulae from the following sources:
+        // https://bottosson.github.io/posts/oklab/#implementation
+        let l = T::from_f64(0.818_933_010_1) * xyz.x + T::from_f64(0.361_866_742_4) * xyz.y
+            - T::from_f64(0.128_859_713_7) * xyz.z;
+        let m = T::from_f64(0.032_984_543_6) * xyz.x
+            + T::from_f64(0.929_311_871_5) * xyz.y
+            + T::from_f64(0.036_145_638_7) * xyz.z;
+        let s = T::from_f64(0.048_200_301_8) * xyz.x
+            + T::from_f64(0.264_366_269_1) * xyz.y
+            + T::from_f64(0.633_851_707_0) * xyz.z;
+
+        let l_prime = l.cbrt();
+        let m_prime = m.cbrt();
+        let s_prime = s.cbrt();
+
+        let l = T::from_f64(0.210_454_255_3) * l_prime + T::from_f64(0.793_617_785_0) * m_prime
+            - T::from_f64(0.004_072_046_8) * s_prime;
+        let a = T::from_f64(1.977_998_495_1) * l_prime - T::from_f64(2.428_592_205_0) * m_prime
+            + T::from_f64(0.450_593_709_9) * s_prime;
+        let b = T::from_f64(0.025_904_037_1) * l_prime + T::from_f64(0.782_771_766_2) * m_prime
+            - T::from_f64(0.808_675_766_0) * s_prime;
+        Self::new(l, a, b)
+    }
+}
+
+impl<T> From<&Oklch<T>> for Oklab<T>
+where
+    T: FloatNumber,
+{
+    fn from(oklch: &Oklch<T>) -> Self {
+        let l = oklch.l;
+        let c = oklch.c;
+        let h = oklch.h.value().to_radians();
+        let a = c * h.cos();
+        let b = c * h.sin();
+        Self::new(l, a, b)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        // Act
+        let actual: Oklab<f32> = Oklab::new(0.607, -0.118, 0.028);
+
+        // Assert
+        assert_eq!(
+            actual,
+            Oklab {
+                l: 0.607,
+                a: -0.118,
+                b: 0.028
+            }
+        );
+    }
+
+    #[test]
+    fn test_fmt() {
+        // Act
+        let oklab: Oklab<f32> = Oklab::new(0.607, -0.118, 0.028);
+        let actual = format!("{}", oklab);
+
+        // Assert
+        assert_eq!(actual, "Oklab(0.61, -0.12, 0.03)");
+    }
+
+    #[rstest]
+    #[case((0.147, 0.241, 0.198), (0.607, -0.118, 0.028))]
+    #[case((0.950, 1.000, 1.089), (1.000, -0.000, 0.000))]
+    #[case((1.000, 0.000, 0.000), (0.442, 1.215, -0.019))]
+    #[case((0.000, 1.000, 0.000), (0.922, -0.671, 0.263))]
+    #[case((0.000, 0.000, 1.000), (0.153, -1.415, -0.449))]
+    fn test_from_xyz(#[case] xyz: (f32, f32, f32), #[case] expected: (f32, f32, f32)) {
+        // Act
+        let xyz: XYZ<f32> = XYZ::new(xyz.0, xyz.1, xyz.2);
+        let actual = Oklab::from(&xyz);
+
+        // Assert
+        assert!((actual.l - expected.0).abs() < 1e-3);
+        assert!((actual.a - expected.1).abs() < 1e-3);
+        assert!((actual.b - expected.2).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_from_oklch() {
+        // Act
+        let oklch: Oklch<f64> = Oklch::new(0.607, 0.121, 166.651);
+        let actual = Oklab::from(&oklch);
+
+        // Assert
+        assert_eq!(actual.l, 0.607);
+        assert!((actual.a + 0.117).abs() < 1e-3);
+        assert!((actual.b - 0.028).abs() < 1e-3);
+    }
+}

--- a/crates/auto-palette/src/color/oklch.rs
+++ b/crates/auto-palette/src/color/oklch.rs
@@ -1,0 +1,137 @@
+use std::fmt::Display;
+
+use num_traits::clamp;
+
+use crate::{
+    color::{Hue, Oklab},
+    math::FloatNumber,
+};
+
+/// Oklch color space representation.
+///
+/// See the following for more details:
+/// [The Oklab color space](https://bottosson.github.io/posts/oklab/#the-oklab-color-space)
+///
+/// # Type Parameters
+/// * `T` - The floating point type.
+///
+/// # Fields
+/// * `l` - The lightness component.
+/// * `c` - The chroma component.
+/// * `h` - The hue component.
+///
+/// # Examples
+/// ```
+/// use auto_palette::color::{Oklab, Oklch};
+///
+/// let oklch: Oklch<f32> = Oklch::new(0.607, 0.121, 166.651);
+/// assert_eq!(format!("{}", oklch), "Oklch(0.61, 0.12, 166.65)");
+///
+/// let oklab: Oklab<_> = (&oklch).into();
+/// assert_eq!(format!("{}", oklab), "Oklab(0.61, -0.12, 0.03)");
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct Oklch<T>
+where
+    T: FloatNumber,
+{
+    pub l: T,
+    pub c: T,
+    pub h: Hue<T>,
+}
+
+impl<T> Oklch<T>
+where
+    T: FloatNumber,
+{
+    /// Creates a new `Oklch` instance.
+    ///
+    /// # Arguments
+    /// * `l` - The lightness component.
+    /// * `c` - The chroma component.
+    /// * `h` - The hue component.
+    ///
+    /// # Returns
+    /// A new `Oklch` instance.
+    #[must_use]
+    pub fn new(l: T, c: T, h: T) -> Self {
+        Self {
+            l: clamp(l, T::zero(), T::from_u32(100)),
+            c: clamp(c, T::zero(), T::from_u32(180)),
+            h: Hue::from_degrees(h),
+        }
+    }
+}
+
+impl<T> Display for Oklch<T>
+where
+    T: FloatNumber,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Oklch({:.2}, {:.2}, {:.2})",
+            self.l,
+            self.c,
+            self.h.value()
+        )
+    }
+}
+
+impl<T> From<&Oklab<T>> for Oklch<T>
+where
+    T: FloatNumber,
+{
+    fn from(oklab: &Oklab<T>) -> Self {
+        // This implementation is based on the formulae from the following sources:
+        // http://www.brucelindbloom.com/index.html?Eqn_Lab_to_LCH.html
+        let l = oklab.l;
+        let c = (oklab.a.powi(2) + oklab.b.powi(2)).sqrt();
+        let h = oklab.b.atan2(oklab.a).to_degrees();
+        Oklch::new(l, c, h)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::Oklab;
+
+    #[test]
+    fn test_new() {
+        // Act
+        let actual = Oklch::new(0.607, 0.121, 166.651);
+
+        // Assert
+        assert_eq!(
+            actual,
+            Oklch {
+                l: 0.607,
+                c: 0.121,
+                h: Hue::from_degrees(166.651)
+            }
+        );
+    }
+
+    #[test]
+    fn test_fmt() {
+        // Act
+        let oklch = Oklch::new(0.607, 0.121, 166.651);
+        let actual = format!("{}", oklch);
+
+        // Assert
+        assert_eq!(actual, "Oklch(0.61, 0.12, 166.65)");
+    }
+
+    #[test]
+    fn test_from_oklab() {
+        // Act
+        let oklab: Oklab<f32> = Oklab::new(0.607, -0.118, 0.028);
+        let actual = Oklch::from(&oklab);
+
+        // Assert
+        assert_eq!(actual.l, 0.607);
+        assert!((actual.c - 0.121).abs() < 1e-3);
+        assert!((actual.h.value() - 166.651).abs() < 1e-3);
+    }
+}


### PR DESCRIPTION
## Description

In this pull request, support for `Oklab` and `Oklch` color spaces and their conversion with `XYZ` has been added.

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
