### PR TITLE
Improve 'auto-palette' crate documentation and default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/t28hub/auto-palette"
 
 [workspace.dependencies]
 assert_cmd               = "2.0.14"
-auto-palette             = { version = "0.2.0", path = "crates/auto-palette" }
+auto-palette             = { version = "0.2.0", path = "crates/auto-palette", default-features = false }
 clap                     = { version = "4.5.4", features = ["cargo"] }
 getrandom                = "0.2.15"
 image                    = "0.25.1"

--- a/crates/auto-palette/Cargo.toml
+++ b/crates/auto-palette/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 rust-version = "1.75.0"
 
 [features]
-default = []
+default = ["image"]
 image   = ["dep:image"]
 wasm    = ["getrandom/js"]
 

--- a/crates/auto-palette/src/algorithm.rs
+++ b/crates/auto-palette/src/algorithm.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-/// Clustering algorithm.
+/// The clustering algorithm to use for color palette extraction.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum Algorithm {

--- a/crates/auto-palette/src/color/hsl.rs
+++ b/crates/auto-palette/src/color/hsl.rs
@@ -7,7 +7,10 @@ use crate::{
     math::FloatNumber,
 };
 
-/// Color represented in the HSL color space.
+/// The HSL color representation.
+///
+/// See the following for more details:
+/// [HSL and HSV - Wikipedia](https://en.wikipedia.org/wiki/HSL_and_HSV)
 ///
 /// # Type Parameters
 /// * `T` - The floating point type.

--- a/crates/auto-palette/src/color/hsv.rs
+++ b/crates/auto-palette/src/color/hsv.rs
@@ -7,7 +7,10 @@ use crate::{
     math::FloatNumber,
 };
 
-/// Color represented in the HSV color space.
+/// The HSV color representation.
+///
+/// See the following for more details:
+/// [HSL and HSV - Wikipedia](https://en.wikipedia.org/wiki/HSL_and_HSV)
 ///
 /// # Type Parameters
 /// * `T` - The floating point type.

--- a/crates/auto-palette/src/color/hue.rs
+++ b/crates/auto-palette/src/color/hue.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::math::FloatNumber;
 
-/// Represents a hue value.
+/// The hue component of a color.
 ///
 /// # Type Parameters
 /// * `T` - The floating point type.

--- a/crates/auto-palette/src/color/lab.rs
+++ b/crates/auto-palette/src/color/lab.rs
@@ -7,7 +7,7 @@ use crate::{
     math::FloatNumber,
 };
 
-/// Color represented in the CIE L*a*b* color space.
+/// The CIE L*a*b* color representation.
 ///
 /// See the following for more details:
 /// [CIELAB color space - Wikipedia](https://en.wikipedia.org/wiki/CIELAB_color_space)

--- a/crates/auto-palette/src/color/lchab.rs
+++ b/crates/auto-palette/src/color/lchab.rs
@@ -7,7 +7,7 @@ use crate::{
     math::FloatNumber,
 };
 
-/// CIE LCH(ab) color space representation.
+/// The CIE L*C*h°(ab) color representation.
 ///
 /// See the following for more details:
 /// [CIE LAB | Cylindrical model](https://en.wikipedia.org/wiki/CIELAB_color_space#Cylindrical_model)

--- a/crates/auto-palette/src/color/lchuv.rs
+++ b/crates/auto-palette/src/color/lchuv.rs
@@ -7,7 +7,7 @@ use crate::{
     math::FloatNumber,
 };
 
-/// CIE LCH(uv) color space representation.
+/// The CIE L*u*v* color representation.
 ///
 /// See the following for more details:
 /// [CIE LUV | Cylindrical representation (CIELCh)](https://en.wikipedia.org/wiki/CIELUV#Cylindrical_representation_(CIELCh))

--- a/crates/auto-palette/src/color/luv.rs
+++ b/crates/auto-palette/src/color/luv.rs
@@ -7,7 +7,7 @@ use crate::{
     math::FloatNumber,
 };
 
-/// CIE L*u*v* color space representation.
+/// The CIE L*u*v* color representation.
 ///
 /// See the following for more details:
 /// [CIELUV - Wikipedia](https://en.wikipedia.org/wiki/CIELUV)

--- a/crates/auto-palette/src/color/mod.rs
+++ b/crates/auto-palette/src/color/mod.rs
@@ -35,7 +35,7 @@ pub use xyz::XYZ;
 
 use crate::math::FloatNumber;
 
-/// A color representation.
+/// The color representation.
 ///
 /// # Type Parameters
 /// * `T` - The floating point type.
@@ -51,7 +51,7 @@ use crate::math::FloatNumber;
 /// assert!(color.is_light());
 /// assert_eq!(color.lightness(), 52.917793);
 /// assert_eq!(color.chroma(), 61.9814870);
-/// assert_eq!(color.hue().value(), 282.6622);
+/// assert_eq!(color.hue().to_degrees(), 282.6622);
 ///
 /// let rgb = color.to_rgb();
 /// assert_eq!(format!("{}", rgb), "RGB(44, 125, 231)");

--- a/crates/auto-palette/src/color/oklab.rs
+++ b/crates/auto-palette/src/color/oklab.rs
@@ -5,7 +5,7 @@ use crate::{
     math::FloatNumber,
 };
 
-/// Oklab color space representation.
+/// The Oklab color representation.
 ///
 /// See the following for more details:
 /// [Oklab - A perceptual color space for image processing](https://bottosson.github.io/posts/oklab/)

--- a/crates/auto-palette/src/color/oklch.rs
+++ b/crates/auto-palette/src/color/oklch.rs
@@ -7,7 +7,7 @@ use crate::{
     math::FloatNumber,
 };
 
-/// Oklch color space representation.
+/// The Oklch color representation.
 ///
 /// See the following for more details:
 /// [The Oklab color space](https://bottosson.github.io/posts/oklab/#the-oklab-color-space)

--- a/crates/auto-palette/src/color/rgb.rs
+++ b/crates/auto-palette/src/color/rgb.rs
@@ -5,7 +5,10 @@ use crate::{
     math::FloatNumber,
 };
 
-/// Color represented in the RGB color space.
+/// The RGB color representation.
+///
+/// See the following for more details:
+/// [RGB color model - Wikipedia](https://en.wikipedia.org/wiki/RGB_color_model)
 ///
 /// # Fields
 /// * `r` - The red component.

--- a/crates/auto-palette/src/color/white_point.rs
+++ b/crates/auto-palette/src/color/white_point.rs
@@ -2,10 +2,10 @@ use std::fmt::Debug;
 
 use crate::math::FloatNumber;
 
-/// White point representation.
+/// The white point representation.
 ///
-/// # References
-/// * [White point - Wikipedia](https://en.wikipedia.org/wiki/White_point)
+/// See the following for more details:
+/// [White point - Wikipedia](https://en.wikipedia.org/wiki/White_point)
 pub trait WhitePoint: Copy + Clone + Debug + Default + PartialEq {
     /// Returns the X component of the white point.
     ///
@@ -46,8 +46,8 @@ pub trait WhitePoint: Copy + Clone + Debug + Default + PartialEq {
 
 /// The D50 white point representation.
 ///
-/// # References
-/// * [Illuminant D50](https://en.wikipedia.org/wiki/Illuminant_D50)
+/// See the following for more details:
+/// [Illuminant D50](https://en.wikipedia.org/wiki/Illuminant_D50)
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct D50;
 
@@ -79,8 +79,8 @@ impl WhitePoint for D50 {
 
 /// The D65 white point representation.
 ///
-/// # References
-/// * [Illuminant D65](https://en.wikipedia.org/wiki/Illuminant_D65)
+/// See the following for more details:
+/// [Illuminant D65](https://en.wikipedia.org/wiki/Illuminant_D65)
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct D65;
 

--- a/crates/auto-palette/src/color/xyz.rs
+++ b/crates/auto-palette/src/color/xyz.rs
@@ -7,7 +7,7 @@ use crate::{
     math::FloatNumber,
 };
 
-/// CIE 1931 XYZ color space representation.
+/// The CIE XYZ color representation.
 ///
 /// See the following for more details:
 /// [CIE 1931 color space - Wikipedia](https://en.wikipedia.org/wiki/CIE_1931_color_space)

--- a/crates/auto-palette/src/error.rs
+++ b/crates/auto-palette/src/error.rs
@@ -1,7 +1,8 @@
 #[cfg(feature = "image")]
 use image::ImageError;
 
-/// Error might occur during the palette extraction process.
+/// The error type for the auto-palette crate.
+/// This error type is used for all errors in the crate.
 #[derive(Debug)]
 pub enum Error {
     /// The image data is empty and cannot be processed.

--- a/crates/auto-palette/src/image.rs
+++ b/crates/auto-palette/src/image.rs
@@ -7,25 +7,28 @@ use image::{DynamicImage, RgbImage, RgbaImage};
 
 use crate::Error;
 
-/// ImageData contains the image width, height, pixel data.
+/// The image data representing the pixel data of an image.
 ///
 /// Each pixel is represented by 4 bytes in RGBA (Red, Green, Blue, Alpha) format.
 /// The pixel data is stored in a linear array of bytes, where each pixel is represented by 4 bytes.
 ///
 /// # Example
 /// ```
-/// use auto_palette::ImageData;
+/// #[cfg(feature = "image")]
+/// {
+///     use auto_palette::ImageData;
 ///
-/// let pixels = [
-///     255, 0, 0, 255, // Red
-///     0, 255, 0, 255, // Green
-///     0, 0, 255, 255, // Blue
-///     0, 0, 0, 255, // Black
-/// ];
-/// let image_data = ImageData::new(2, 2, &pixels).unwrap();
-/// assert_eq!(image_data.width(), 2);
-/// assert_eq!(image_data.height(), 2);
-/// assert_eq!(image_data.data(), &pixels);
+///     let pixels = [
+///         255, 0, 0, 255, // Red
+///         0, 255, 0, 255, // Green
+///         0, 0, 255, 255, // Blue
+///         0, 0, 0, 255, // Black
+///     ];
+///     let image_data = ImageData::new(2, 2, &pixels).unwrap();
+///     assert_eq!(image_data.width(), 2);
+///     assert_eq!(image_data.height(), 2);
+///     assert_eq!(image_data.data(), &pixels);
+/// }
 /// ```
 #[derive(Debug)]
 pub struct ImageData<'a> {

--- a/crates/auto-palette/src/swatch.rs
+++ b/crates/auto-palette/src/swatch.rs
@@ -1,6 +1,6 @@
 use crate::{color::Color, math::FloatNumber};
 
-/// Swatch struct representing a color, position, and population.
+/// The swatch representation containing the color, position, and population.
 ///
 /// # Type Parameters
 /// * `T` - The floating point type.

--- a/crates/auto-palette/src/theme.rs
+++ b/crates/auto-palette/src/theme.rs
@@ -6,7 +6,17 @@ use crate::{
     Error,
 };
 
-/// The theme of a color.
+/// The theme representation for selecting colors.
+///
+/// # Examples
+/// ```
+/// use std::str::FromStr;
+///
+/// use auto_palette::Theme;
+///
+/// let theme = Theme::from_str("basic").unwrap();
+/// assert_eq!(format!("{}", theme), "Basic");
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Theme {
     /// Basic theme.


### PR DESCRIPTION
## Description

In this pull request, the `auto-palette` crate has been enhanced by improving its Rustdoc and adding the `image` feature to the default features. These changes make the crate more accessible and easier to use for developers.

## Related Issue

No related isuue.

## Type of Change

- [x] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [Contributing](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
