### PR TITLE
Support colored output in auto-palette CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/t28hub/auto-palette"
 assert_cmd               = "2.0.14"
 auto-palette             = { version = "0.3.0", path = "crates/auto-palette", default-features = false }
 clap                     = { version = "4.5.4", features = ["cargo"] }
+colored                  = "2.1.0"
 getrandom                = "0.2.15"
 image                    = "0.25.1"
 num-traits               = "0.2.18"

--- a/biome.json
+++ b/biome.json
@@ -3,7 +3,7 @@
   "files": {
     "ignoreUnknown": true,
     "include": ["**/*.js", "**/*.ts", "**/*.json"],
-    "ignore": ["node_modules", "coverage", "dist", "pkg"]
+    "ignore": ["node_modules", "coverage", "dist", "pkg", "target"]
   },
   "linter": {
     "enabled": true,

--- a/crates/auto-palette-cli/Cargo.toml
+++ b/crates/auto-palette-cli/Cargo.toml
@@ -21,7 +21,9 @@ rust-version = "1.75.0"
 [dependencies]
 auto-palette = { workspace = true, features = ["image"] }
 clap         = { workspace = true, features = ["derive"] }
+colored      = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
+rstest     = { workspace = true }

--- a/crates/auto-palette-cli/src/env.rs
+++ b/crates/auto-palette-cli/src/env.rs
@@ -1,0 +1,113 @@
+use std::env;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Env {
+    colorterm: Option<String>,
+    no_color: Option<String>,
+}
+
+impl Env {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            colorterm: env::var("COLORTERM").ok(),
+            no_color: env::var("NO_COLOR").ok(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_truecolor_enabled(&self) -> bool {
+        self.colorterm
+            .as_deref()
+            .map(|v| v.to_lowercase() == "truecolor" || v.to_lowercase() == "24bit")
+            .unwrap_or(false)
+    }
+
+    #[must_use]
+    pub fn is_color_disabled(&self) -> bool {
+        self.no_color
+            .as_deref()
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        // Arrange
+        // env::remove_var("COLORTERM");
+        // env::remove_var("NO_COLOR");
+        env::set_var("COLORTERM", "truecolor");
+        env::set_var("NO_COLOR", "1");
+
+        // Act
+        let actual = Env::new();
+
+        // Assert
+        assert_eq!(
+            actual,
+            Env {
+                colorterm: Some("truecolor".to_string()),
+                no_color: Some("1".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_new_with_no_env() {
+        // Arrange
+        env::remove_var("COLORTERM");
+        env::remove_var("NO_COLOR");
+
+        // Act
+        let actual = Env::new();
+
+        // Assert
+        assert_eq!(
+            actual,
+            Env {
+                colorterm: None,
+                no_color: None,
+            }
+        );
+    }
+
+    #[rstest]
+    #[case("truecolor", true)]
+    #[case("24bit", true)]
+    #[case("8bit", false)]
+    #[case("", false)]
+    fn test_is_truecolor_enabled(#[case] value: &str, #[case] expected: bool) {
+        // Arrange
+        env::set_var("COLORTERM", value);
+
+        // Act
+        let actual = Env::new().is_truecolor_enabled();
+
+        // Assert
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case("1", true)]
+    #[case("true", true)]
+    #[case("false", true)]
+    #[case("0", false)]
+    #[case("", false)]
+    fn test_is_color_disabled(#[case] value: &str, #[case] expected: bool) {
+        // Arrange
+        env::set_var("NO_COLOR", value);
+
+        // Act
+        let actual = Env::new().is_color_disabled();
+
+        // Assert
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/auto-palette-cli/src/main.rs
+++ b/crates/auto-palette-cli/src/main.rs
@@ -2,10 +2,19 @@ use std::{process, time::Instant};
 
 use auto_palette::{ImageData, Palette};
 use clap::Parser;
+use colored::Colorize;
 
-use crate::args::Options;
+use crate::{args::Options, env::Env};
 
 mod args;
+mod env;
+
+#[derive(Debug)]
+pub enum Style {
+    TrueColor,
+    Ansi256,
+    NoColor,
+}
 
 fn main() {
     let options = Options::parse();
@@ -19,13 +28,31 @@ fn main() {
         process::exit(1);
     };
 
-    let color_space = options.color;
+    let env = Env::new();
+    let style = match (env.is_truecolor_enabled(), env.is_color_disabled()) {
+        (true, false) => Style::TrueColor,
+        (false, false) => Style::Ansi256,
+        (false, true) => Style::NoColor,
+        (true, true) => Style::NoColor,
+    };
     let swatches = options.theme.map_or_else(
         || palette.find_swatches(options.count),
         |theme| palette.find_swatches_with_theme(options.count, theme.into()),
     );
     for swatch in swatches {
-        println!("{}", color_space.as_string(swatch.color()));
+        let color_string = options.color.as_string(swatch.color());
+        let color = match style {
+            Style::TrueColor => {
+                let rgb = swatch.color().to_rgb();
+                color_string.bold().on_truecolor(rgb.r, rgb.g, rgb.b)
+            }
+            Style::Ansi256 => {
+                let rgb = swatch.color().to_rgb();
+                color_string.bold().on_truecolor(rgb.r, rgb.g, rgb.b)
+            }
+            Style::NoColor => color_string.bold(),
+        };
+        println!("{} {:?}", color, swatch.position());
     }
     println!(
         "Extracted {} swatch(es) in {}.{:03} seconds",


### PR DESCRIPTION
## Description

In this pull request, colored output has been supported by the auto-palette CLI based on `COLORTERM` and `NO_COLOR` environment variables.

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [Contributing](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
