### PR TITLE
Implement image resizing to optimize palette extraction and add --no-resize option

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@
 <!-- Please check the following items before submitting a pull request. -->
 
 - [ ] My changes are consistent with the project's coding style.
-- [ ] I have read the [Contributing](/CONTRIBUTING.md) guidelines.
+- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
 - [ ] I have updated the documentation accordingly.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.

--- a/crates/auto-palette-cli/Cargo.toml
+++ b/crates/auto-palette-cli/Cargo.toml
@@ -22,6 +22,7 @@ rust-version = "1.75.0"
 auto-palette = { workspace = true, features = ["image"] }
 clap         = { workspace = true, features = ["derive"] }
 colored      = { workspace = true }
+image        = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/auto-palette-cli/src/args.rs
+++ b/crates/auto-palette-cli/src/args.rs
@@ -63,6 +63,9 @@ pub struct Options {
         ignore_case = true,
     )]
     pub color: ColorArg,
+
+    #[arg(long, help = "Disable image resizing before extracting the palette.")]
+    pub no_resize: bool,
 }
 
 #[derive(Debug, Default, Copy, Clone, ValueEnum)]


### PR DESCRIPTION
## Description

This pull request introduces an image resizing feature to optimize the palette extraction process.  
It also adds a `--no-resize` option to the CLI tool, allowing users to disable the image resizing if desired.

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [Contributing](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
