### PR TITLE
Add 8-bit ANSI 256 color support to auto-palette

### DIFF
--- a/crates/auto-palette/src/color/ansi16.rs
+++ b/crates/auto-palette/src/color/ansi16.rs
@@ -5,7 +5,7 @@ use crate::{
     FloatNumber,
 };
 
-/// The 4-bit ANSI 16 color.
+/// The 4-bit ANSI 16 color representation.
 ///
 /// See the following for more details:
 /// [ANSI escape code - Wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit)
@@ -21,7 +21,8 @@ use crate::{
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Ansi16 {
-    code: u8,
+    /// The ANSI 16 color code.
+    pub(crate) code: u8,
 }
 
 impl Ansi16 {
@@ -43,6 +44,26 @@ impl Ansi16 {
             code
         );
         Self { code }
+    }
+
+    /// Returns the ANSI 16 color code for foreground text.
+    ///
+    /// # Returns
+    /// The ANSI 16 color code for foreground text.
+    #[inline]
+    #[must_use]
+    pub fn foreground(&self) -> u8 {
+        self.code
+    }
+
+    /// Returns the ANSI 16 color code for background text.
+    ///
+    /// # Returns
+    /// The ANSI 16 color code for background text.
+    #[inline]
+    #[must_use]
+    pub fn background(&self) -> u8 {
+        self.code + 10
     }
 
     /// Creates a new `Ansi16` instance with the black color.
@@ -214,16 +235,16 @@ impl Display for Ansi16 {
 
 impl From<&RGB> for Ansi16 {
     fn from(rgb: &RGB) -> Self {
-        let hsv = HSV::<f64>::from(rgb);
+        let hsv = HSV::<f32>::from(rgb);
         let value = (hsv.v * 100.0 / 50.0).round().to_u8_unsafe();
         if value == 0 {
             return Ansi16::new(30);
         }
 
-        let max = RGB::max_value::<f64>();
-        let r = (rgb.r as f64 / max).round() as u8;
-        let g = (rgb.g as f64 / max).round() as u8;
-        let b = (rgb.b as f64 / max).round() as u8;
+        let max = RGB::max_value::<f32>();
+        let r = (rgb.r as f32 / max).round() as u8;
+        let g = (rgb.g as f32 / max).round() as u8;
+        let b = (rgb.b as f32 / max).round() as u8;
         let code = 30 + (b << 2 | g << 1 | r);
         Self {
             code: if value == 2 { code + 60 } else { code },
@@ -244,6 +265,8 @@ mod tests {
 
         // Assert
         assert_eq!(actual, Ansi16 { code: 30 });
+        assert_eq!(actual.foreground(), 30);
+        assert_eq!(actual.background(), 40);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/ansi256.rs
+++ b/crates/auto-palette/src/color/ansi256.rs
@@ -1,0 +1,163 @@
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
+
+use crate::color::{Ansi16, RGB};
+
+/// The 8-bit ANSI 256 color.
+///
+/// See the following for more details:
+/// [ANSI escape code - Wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit)
+///
+/// # Examples
+/// ```
+/// use auto_palette::color::{Ansi256, RGB};
+///
+/// let rgb = RGB::new(30, 215, 96);
+/// let ansi256 = Ansi256::from(&rgb);
+/// assert_eq!(ansi256.code(), 78);
+/// assert_eq!(format!("{}", ansi256), "ANSI256(78)");
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ansi256 {
+    code: u8,
+}
+
+impl Ansi256 {
+    /// Creates a new `Ansi256` instance.
+    ///
+    /// # Arguments
+    /// * `code` - The ANSI 256 color code.
+    ///
+    /// # Returns
+    /// A new `Ansi256` instance.
+    #[must_use]
+    pub fn new(code: u8) -> Self {
+        Self { code }
+    }
+
+    /// Returns the ANSI 256 color code.
+    ///
+    /// # Returns
+    /// The ANSI 256 color code.
+    #[must_use]
+    pub fn code(&self) -> u8 {
+        self.code
+    }
+}
+
+impl Display for Ansi256 {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "ANSI256({})", self.code)
+    }
+}
+
+impl From<&RGB> for Ansi256 {
+    fn from(rgb: &RGB) -> Self {
+        let r = rgb.r as f32;
+        let g = rgb.g as f32;
+        let b = rgb.b as f32;
+        let code = if (r == g) && (g == b) {
+            // Grayscale colors
+            if r < 8.0 {
+                16 // Black
+            } else if r > 248.0 {
+                231 // White
+            } else {
+                232 + ((r - 8.0) / 247.0 * 24.0).round() as u8
+            }
+        } else {
+            let r = (r / 51.0).round() as u8;
+            let g = (g / 51.0).round() as u8;
+            let b = (b / 51.0).round() as u8;
+            16 + 36 * r + 6 * g + b
+        };
+        Self::new(code)
+    }
+}
+
+impl From<&Ansi16> for Ansi256 {
+    fn from(ansi16: &Ansi16) -> Self {
+        let code = ansi16.code;
+        if (30..=37).contains(&code) {
+            Self::new(code - 30)
+        } else {
+            Self::new(code - 82)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(0)]
+    #[case(128)]
+    #[case(255)]
+    fn test_new(#[case] code: u8) {
+        // Act
+        let actual = Ansi256::new(code);
+
+        // Assert
+        assert_eq!(actual, Ansi256 { code });
+        assert_eq!(actual.code(), code);
+    }
+
+    #[test]
+    fn test_fmt() {
+        // Act
+        let ansi256 = Ansi256::new(120);
+        let actual = format!("{}", ansi256);
+
+        // Assert
+        assert_eq!(actual, "ANSI256(120)");
+    }
+
+    #[rstest]
+    #[case::black((0, 0, 0), 16)]
+    #[case::white((255, 255, 255), 231)]
+    #[case::gray((192, 192, 192), 250)]
+    #[case::red((192, 0, 0), 160)]
+    #[case::green((0, 192, 0), 40)]
+    #[case::blue((0, 0, 192), 20)]
+    #[case::yellow((192, 192, 0), 184)]
+    #[case::cyan((0, 192, 192), 44)]
+    #[case::magenta((192, 0, 192), 164)]
+    fn test_from_rgb(#[case] rgb: (u8, u8, u8), #[case] expected: u8) {
+        // Act
+        let rgb = RGB::new(rgb.0, rgb.1, rgb.2);
+        let actual = Ansi256::from(&rgb);
+
+        // Assert
+        assert_eq!(actual.code(), expected);
+    }
+
+    #[rstest]
+    #[case::black(Ansi16::black(), 0)]
+    #[case::red(Ansi16::red(), 1)]
+    #[case::green(Ansi16::green(), 2)]
+    #[case::yellow(Ansi16::yellow(), 3)]
+    #[case::blue(Ansi16::blue(), 4)]
+    #[case::magenta(Ansi16::magenta(), 5)]
+    #[case::cyan(Ansi16::cyan(), 6)]
+    #[case::white(Ansi16::white(), 7)]
+    #[case::bright_black(Ansi16::bright_black(), 8)]
+    #[case::bright_red(Ansi16::bright_red(), 9)]
+    #[case::bright_green(Ansi16::bright_green(), 10)]
+    #[case::bright_yellow(Ansi16::bright_yellow(), 11)]
+    #[case::bright_blue(Ansi16::bright_blue(), 12)]
+    #[case::bright_magenta(Ansi16::bright_magenta(), 13)]
+    #[case::bright_cyan(Ansi16::bright_cyan(), 14)]
+    #[case::bright_white(Ansi16::bright_white(), 15)]
+    fn test_from_ansi16(#[case] ansi16: Ansi16, #[case] expected: u8) {
+        // Act
+        let actual = Ansi256::from(&ansi16);
+
+        // Assert
+        assert_eq!(actual.code(), expected);
+    }
+}

--- a/crates/auto-palette/src/color/mod.rs
+++ b/crates/auto-palette/src/color/mod.rs
@@ -1,4 +1,5 @@
-mod ansi;
+mod ansi16;
+mod ansi256;
 mod hsl;
 mod hsv;
 mod hue;
@@ -19,7 +20,8 @@ use std::{
     str::FromStr,
 };
 
-pub use ansi::Ansi16;
+pub use ansi16::Ansi16;
+pub use ansi256::Ansi256;
 pub use hsl::HSL;
 pub use hsv::HSV;
 pub use hue::Hue;


### PR DESCRIPTION
## Description

This pull request adds support for `ANSI256` colors in the auto-palette crate.
The changes include the implementation of a conversion from `RGB` color space to `ANSI256` and from `ANSI16` to `ANSI256`, allowing users to convert their `RGB` or `ANSI16` colors to the closest matching `ANSI256` color.

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
