### PR TITLE
Implement ANSI16 and ANSI256 conversion in Color struct

### DIFF
--- a/crates/auto-palette/src/color/mod.rs
+++ b/crates/auto-palette/src/color/mod.rs
@@ -295,6 +295,26 @@ where
         let oklab = self.to_oklab();
         Oklch::from(&oklab)
     }
+
+    /// Converts this color to the 4-bit ANSI 16 color space.
+    ///
+    /// # Returns
+    /// The converted `Ansi16` color.
+    #[must_use]
+    pub fn to_ansi16(&self) -> Ansi16 {
+        let rgb = self.to_rgb();
+        Ansi16::from(&rgb)
+    }
+
+    /// Converts this color to the 8-bit ANSI 256 color space.
+    ///
+    /// # Returns
+    /// The converted `Ansi256` color.
+    #[must_use]
+    pub fn to_ansi256(&self) -> Ansi256 {
+        let rgb = self.to_rgb();
+        Ansi256::from(&rgb)
+    }
 }
 
 impl<T> Display for Color<T>
@@ -533,17 +553,35 @@ mod tests {
     }
 
     #[test]
-    fn test_from_lchab() {
+    fn test_to_lchab() {
         // Act
         let color: Color<f32> = Color::new(91.1120, -48.0806, -14.1521);
         let actual = color.to_lchab();
-
-        println!("{:?}", actual);
 
         // Assert
         assert_eq!(actual.l, 91.1120);
         assert!((actual.c - 50.120).abs() < 1e-3);
         assert!((actual.h.to_degrees() - 196.401).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_to_anis16() {
+        // Act
+        let color: Color<f32> = Color::new(91.1120, -48.0806, -14.1521);
+        let actual = color.to_ansi16();
+
+        // Assert
+        assert_eq!(actual, Ansi16::bright_cyan());
+    }
+
+    #[test]
+    fn test_to_ansi256() {
+        // Act
+        let color: Color<f32> = Color::new(91.1120, -48.0806, -14.1521);
+        let actual = color.to_ansi256();
+
+        // Assert
+        assert_eq!(actual, Ansi256::new(51));
     }
 
     #[test]


### PR DESCRIPTION
## Description

This pull request introduces the functionality of converting colors to `ANSI16` and `ANSI256` in the `Color` struct.  
This enhancement allows users to easily convert their colors to these widely used ANSI color spaces.

## Related Issue

- https://github.com/t28hub/auto-palette/pull/55
- https://github.com/t28hub/auto-palette/pull/56

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
