### PR TITLE
Implement custom terminal styling and remove colored crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ repository = "https://github.com/t28hub/auto-palette"
 assert_cmd               = "2.0.14"
 auto-palette             = { version = "0.3.0", path = "crates/auto-palette", default-features = false }
 clap                     = { version = "4.5.4", features = ["cargo"] }
-colored                  = "2.1.0"
 getrandom                = "0.2.15"
 image                    = "0.25.1"
 num-traits               = "0.2.18"

--- a/crates/auto-palette-cli/Cargo.toml
+++ b/crates/auto-palette-cli/Cargo.toml
@@ -21,7 +21,6 @@ rust-version = "1.75.0"
 [dependencies]
 auto-palette = { workspace = true, features = ["image"] }
 clap         = { workspace = true, features = ["derive"] }
-colored      = { workspace = true }
 image        = { workspace = true }
 
 [dev-dependencies]

--- a/crates/auto-palette-cli/src/color.rs
+++ b/crates/auto-palette-cli/src/color.rs
@@ -1,0 +1,84 @@
+use auto_palette::color;
+
+/// The color type for the terminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ColorType {
+    /// The 4-bit ANSI color.
+    #[allow(dead_code)]
+    Ansi16(color::Ansi16),
+    /// The 8-bit ANSI color.
+    Ansi256(color::Ansi256),
+    /// The 24-bit true color.
+    TrueColor(color::RGB),
+    /// No color.
+    NoColor,
+}
+
+impl ColorType {
+    /// Returns the ANSI color code for background.
+    ///
+    /// # Returns
+    /// The ANSI color code for background.
+    #[inline]
+    #[must_use]
+    pub fn bg_code(&self) -> String {
+        match self {
+            Self::Ansi16(color) => format!("{}", color.background()),
+            Self::Ansi256(color) => format!("48;5;{}", color.code()),
+            Self::TrueColor(color) => format!("48;2;{};{};{}", color.r, color.g, color.b),
+            Self::NoColor => String::from("49"),
+        }
+    }
+
+    /// Returns the ANSI color code for foreground.
+    ///
+    /// # Returns
+    /// The ANSI color code for foreground.
+    #[inline]
+    #[must_use]
+    pub fn fg_code(&self) -> String {
+        match self {
+            Self::Ansi16(color) => format!("{}", color.foreground()),
+            Self::Ansi256(color) => format!("38;5;{}", color.code()),
+            Self::TrueColor(color) => format!("38;2;{};{};{}", color.r, color.g, color.b),
+            Self::NoColor => String::from("39"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use auto_palette::color::{Ansi16, Ansi256, RGB};
+
+    use super::*;
+
+    #[test]
+    fn test_bg_code() {
+        let color = ColorType::Ansi16(Ansi16::bright_blue());
+        assert_eq!(color.bg_code(), "104");
+
+        let color = ColorType::Ansi256(Ansi256::new(33));
+        assert_eq!(color.bg_code(), "48;5;33");
+
+        let color = ColorType::TrueColor(RGB::new(0, 102, 255));
+        assert_eq!(color.bg_code(), "48;2;0;102;255");
+
+        let color = ColorType::NoColor;
+        assert_eq!(color.bg_code(), "49");
+    }
+
+    #[test]
+    fn test_fg_code() {
+        let color = ColorType::Ansi16(Ansi16::bright_blue());
+        assert_eq!(color.fg_code(), "94");
+
+        let color = ColorType::Ansi256(Ansi256::new(33));
+        assert_eq!(color.fg_code(), "38;5;33");
+
+        let color = ColorType::TrueColor(RGB::new(0, 102, 255));
+        assert_eq!(color.fg_code(), "38;2;0;102;255");
+
+        let color = ColorType::NoColor;
+        assert_eq!(color.fg_code(), "39");
+    }
+}

--- a/crates/auto-palette-cli/src/style.rs
+++ b/crates/auto-palette-cli/src/style.rs
@@ -1,0 +1,420 @@
+use std::{collections::BTreeSet, fmt::Display};
+
+use crate::color::ColorType;
+
+/// The style of the text in the terminal.
+///
+/// See the following for more details:
+/// [SGR (Select Graphic Rendition) parameters - Wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Style {
+    Bold,
+    Dim,
+    Italic,
+    Underline,
+    Blink,
+    Reverse,
+    Hidden,
+}
+
+impl Style {
+    /// Returns the ANSI escape code for this style.
+    ///
+    /// # Returns
+    /// The ANSI escape code for this style.
+    #[inline]
+    #[must_use]
+    fn code(&self) -> u8 {
+        match self {
+            Self::Bold => 1,
+            Self::Dim => 2,
+            Self::Italic => 3,
+            Self::Underline => 4,
+            Self::Blink => 5,
+            Self::Reverse => 7,
+            Self::Hidden => 8,
+        }
+    }
+}
+
+/// The styled string in the terminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StyledString {
+    value: String,
+    foreground: Option<ColorType>,
+    background: Option<ColorType>,
+    styles: BTreeSet<Style>,
+}
+
+#[allow(dead_code)]
+impl StyledString {
+    /// Creates a new `StyledString` instance with the given value.
+    ///
+    /// # Arguments
+    /// * `value` - The value of this string.
+    ///
+    /// # Returns
+    /// A new `StyledString` instance.
+    #[inline]
+    #[must_use]
+    fn new(value: String) -> Self {
+        Self {
+            value,
+            foreground: None,
+            background: None,
+            styles: BTreeSet::new(),
+        }
+    }
+
+    /// Applies the color to this string.
+    ///
+    /// # Arguments
+    /// * `color` - The color of this string.
+    ///
+    /// # Returns
+    /// The styled string with the color.
+    #[inline]
+    #[must_use]
+    pub fn color(mut self, color: ColorType) -> Self {
+        self.foreground = Some(color);
+        self
+    }
+
+    /// Applies the background color to this string.
+    ///
+    /// # Arguments
+    /// * `color` - The background color of this string.
+    ///
+    /// # Returns
+    /// The styled string with the background color.
+    #[inline]
+    #[must_use]
+    pub fn background(mut self, color: ColorType) -> Self {
+        self.background = Some(color);
+        self
+    }
+
+    /// Applies the bold style to this string.
+    ///
+    /// # Returns
+    /// The styled string with the bold style.
+    #[inline]
+    #[must_use]
+    pub fn bold(mut self) -> Self {
+        self.styles.insert(Style::Bold);
+        self
+    }
+
+    /// Applies the dim style to this string.
+    ///
+    /// # Returns
+    /// The styled string with the dim style.
+    #[inline]
+    #[must_use]
+    pub fn dim(mut self) -> Self {
+        self.styles.insert(Style::Dim);
+        self
+    }
+
+    /// Applies the italic style to this string.
+    ///
+    /// # Returns
+    /// The styled string with the italic style.
+    #[inline]
+    #[must_use]
+    pub fn italic(mut self) -> Self {
+        self.styles.insert(Style::Italic);
+        self
+    }
+
+    /// Applies the underline style to this string.
+    ///
+    /// # Returns
+    /// The styled string with the underline style.
+    #[inline]
+    #[must_use]
+    pub fn underline(mut self) -> Self {
+        self.styles.insert(Style::Underline);
+        self
+    }
+
+    /// Applies the blink style to this string.
+    ///
+    /// # Returns
+    /// The styled string with the blink style.
+    #[inline]
+    #[must_use]
+    pub fn blink(mut self) -> Self {
+        self.styles.insert(Style::Blink);
+        self
+    }
+
+    /// Applies the reverse style to this string.
+    ///
+    /// # Returns
+    /// The styled string with the reverse style.
+    #[inline]
+    #[must_use]
+    pub fn reverse(mut self) -> Self {
+        self.styles.insert(Style::Reverse);
+        self
+    }
+
+    /// Applies the hidden style to this string.
+    ///
+    /// # Returns
+    /// The styled string with the hidden style.
+    #[inline]
+    #[must_use]
+    pub fn hidden(mut self) -> Self {
+        self.styles.insert(Style::Hidden);
+        self
+    }
+}
+
+impl Display for StyledString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut applied = false;
+        if let Some(foreground) = &self.foreground {
+            write!(f, "\x1b[{}m", foreground.fg_code())?;
+            applied = true;
+        }
+
+        if let Some(background) = &self.background {
+            write!(f, "\x1b[{}m", background.bg_code())?;
+            applied = true;
+        }
+
+        for style in &self.styles {
+            write!(f, "\x1b[{}m", style.code())?;
+            applied = true;
+        }
+
+        write!(f, "{}", self.value)?;
+
+        if applied {
+            write!(f, "\x1b[0m")?;
+        }
+        Ok(())
+    }
+}
+
+/// Creates a new `StyledString` instance with the given value.
+///
+/// # Arguments
+/// * `value` - The value of this string.
+///
+/// # Returns
+/// A new `StyledString` instance.
+#[inline]
+#[must_use]
+pub fn styled<T>(value: T) -> StyledString
+where
+    T: Into<String>,
+{
+    StyledString::new(value.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use auto_palette::color::{Ansi16, Ansi256, RGB};
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::bold(Style::Bold, 1)]
+    #[case::dim(Style::Dim, 2)]
+    #[case::italic(Style::Italic, 3)]
+    #[case::underline(Style::Underline, 4)]
+    #[case::blink(Style::Blink, 5)]
+    #[case::reverse(Style::Reverse, 7)]
+    #[case::hidden(Style::Hidden, 8)]
+    fn test_style_code(#[case] style: Style, #[case] expected: u8) {
+        // Act
+        let actual = style.code();
+
+        // Assert
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_new() {
+        // Act
+        let actual = StyledString::new("Hello, world!".into());
+
+        // Assert
+        assert_eq!(
+            actual,
+            StyledString {
+                value: String::from("Hello, world!"),
+                foreground: None,
+                background: None,
+                styles: BTreeSet::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_color_ansi16() {
+        // Arrange
+        let color = ColorType::Ansi16(Ansi16::black());
+
+        // Act
+        let actual = styled("Hello, world!").color(color.clone());
+
+        // Assert
+        assert_eq!(
+            actual,
+            StyledString {
+                value: String::from("Hello, world!"),
+                foreground: Some(color),
+                background: None,
+                styles: BTreeSet::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_color_ansi256() {
+        // Arrange
+        let color = ColorType::Ansi256(Ansi256::new(86));
+
+        // Act
+        let actual = styled("Hello, world!").color(color.clone());
+
+        // Assert
+        assert_eq!(
+            actual,
+            StyledString {
+                value: String::from("Hello, world!"),
+                foreground: Some(color),
+                background: None,
+                styles: BTreeSet::new(),
+            }
+        );
+        assert_eq!(format!("{}", actual), "\x1b[38;5;86mHello, world!\x1b[0m");
+    }
+
+    #[test]
+    fn test_color_true_color() {
+        // Arrange
+        let color = ColorType::TrueColor(RGB::new(30, 215, 96));
+
+        // Act
+        let actual = styled("Hello, world!").color(color.clone());
+
+        // Assert
+        assert_eq!(
+            actual,
+            StyledString {
+                value: String::from("Hello, world!"),
+                foreground: Some(color),
+                background: None,
+                styles: BTreeSet::new(),
+            }
+        );
+        assert_eq!(
+            format!("{}", actual),
+            "\x1b[38;2;30;215;96mHello, world!\x1b[0m"
+        );
+    }
+
+    #[test]
+    fn test_background() {
+        // Arrange
+        let color = ColorType::TrueColor(RGB::new(30, 215, 96));
+
+        // Act
+        let actual = styled("Hello, world!").background(color.clone());
+
+        // Assert
+        assert_eq!(
+            actual,
+            StyledString {
+                value: String::from("Hello, world!"),
+                foreground: None,
+                background: Some(color),
+                styles: BTreeSet::new(),
+            }
+        );
+        assert_eq!(
+            format!("{}", actual),
+            "\x1b[48;2;30;215;96mHello, world!\x1b[0m"
+        );
+    }
+
+    #[rstest]
+    #[case::bold(styled("Hello, world!").bold(), vec![Style::Bold], "\x1b[1mHello, world!\x1b[0m")]
+    #[case::dim(styled("Hello, world!").dim(), vec![Style::Dim], "\x1b[2mHello, world!\x1b[0m")]
+    #[case::italic(styled("Hello, world!").italic(), vec![Style::Italic], "\x1b[3mHello, world!\x1b[0m")]
+    #[case::underline(styled("Hello, world!").underline(), vec![Style::Underline], "\x1b[4mHello, world!\x1b[0m")]
+    #[case::blink(styled("Hello, world!").blink(), vec![Style::Blink], "\x1b[5mHello, world!\x1b[0m")]
+    #[case::reverse(styled("Hello, world!").reverse(), vec![Style::Reverse], "\x1b[7mHello, world!\x1b[0m")]
+    #[case::hidden(styled("Hello, world!").hidden(), vec![Style::Hidden], "\x1b[8mHello, world!\x1b[0m")]
+    fn test_styled(
+        #[case] actual: StyledString,
+        #[case] styles: Vec<Style>,
+        #[case] expected: &str,
+    ) {
+        // Assert
+        assert_eq!(
+            actual,
+            StyledString {
+                value: String::from("Hello, world!"),
+                foreground: None,
+                background: None,
+                styles: styles.iter().cloned().collect(),
+            }
+        );
+        assert_eq!(format!("{}", actual), expected);
+    }
+
+    #[test]
+    fn test_styled_no_style() {
+        // Act
+        let actual = styled("Hello, world!");
+
+        // Assert
+        assert_eq!(
+            actual,
+            StyledString {
+                value: String::from("Hello, world!"),
+                foreground: None,
+                background: None,
+                styles: BTreeSet::new(),
+            }
+        );
+        assert_eq!(format!("{}", actual), "Hello, world!");
+    }
+
+    #[test]
+    fn test_styled_multiple_styles() {
+        // Act
+        let actual = styled("Hello, world!")
+            .color(ColorType::TrueColor(RGB::new(255, 255, 255)))
+            .background(ColorType::TrueColor(RGB::new(30, 215, 96)))
+            .bold()
+            .italic()
+            .underline()
+            .reverse();
+
+        // Assert
+        assert_eq!(
+            actual,
+            StyledString {
+                value: String::from("Hello, world!"),
+                foreground: Some(ColorType::TrueColor(RGB::new(255, 255, 255))),
+                background: Some(ColorType::TrueColor(RGB::new(30, 215, 96))),
+                styles: [Style::Bold, Style::Italic, Style::Underline, Style::Reverse]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            }
+        );
+        assert_eq!(
+            format!("{}", actual),
+            "\x1b[38;2;255;255;255m\x1b[48;2;30;215;96m\x1b[1m\x1b[3m\x1b[4m\x1b[7mHello, world!\x1b[0m"
+        );
+    }
+}

--- a/crates/auto-palette/src/color/ansi16.rs
+++ b/crates/auto-palette/src/color/ansi16.rs
@@ -16,7 +16,7 @@ use crate::{color::RGB, FloatNumber};
 /// assert_eq!(ansi16, Ansi16::bright_green());
 /// assert_eq!(format!("{}", ansi16), "ANSI16(92)");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ansi16 {
     /// The ANSI 16 color code.
     pub(crate) code: u8,

--- a/crates/auto-palette/src/color/ansi256.rs
+++ b/crates/auto-palette/src/color/ansi256.rs
@@ -22,7 +22,7 @@ use crate::{
 /// assert_eq!(ansi256.code(), 78);
 /// assert_eq!(format!("{}", ansi256), "ANSI256(78)");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ansi256 {
     code: u8,
 }

--- a/crates/auto-palette/src/color/hsl.rs
+++ b/crates/auto-palette/src/color/hsl.rs
@@ -28,7 +28,7 @@ use crate::{
 /// let hsl = HSL::<f32>::from(&rgb);
 /// assert_eq!(format!("{}", hsl), "HSL(60.00, 1.00, 0.50)");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HSL<T>
 where
     T: FloatNumber,

--- a/crates/auto-palette/src/color/hsv.rs
+++ b/crates/auto-palette/src/color/hsv.rs
@@ -28,7 +28,7 @@ use crate::{
 /// let hsv = HSV::<f32>::from(&rgb);
 /// assert_eq!(format!("{}", hsv), "HSV(60.00, 1.00, 1.00)");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HSV<T>
 where
     T: FloatNumber,

--- a/crates/auto-palette/src/color/hue.rs
+++ b/crates/auto-palette/src/color/hue.rs
@@ -18,7 +18,7 @@ use crate::math::FloatNumber;
 /// assert_eq!(hue.to_radians(), 240.0 / 180.0 * PI);
 /// assert_eq!(format!("{}", hue), "240.00");
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Hue<T>(T)
 where
     T: FloatNumber;

--- a/crates/auto-palette/src/color/lab.rs
+++ b/crates/auto-palette/src/color/lab.rs
@@ -32,7 +32,7 @@ use crate::{
 /// let lchab: LCHab<_> = (&lab).into();
 /// assert_eq!(format!("{}", lchab), "LCH(ab)(87.74, 119.78, 136.02)");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Lab<T, W = D65>
 where
     T: FloatNumber,

--- a/crates/auto-palette/src/color/lchab.rs
+++ b/crates/auto-palette/src/color/lchab.rs
@@ -31,7 +31,7 @@ use crate::{
 /// let lab: Lab<_> = (&lchab).into();
 /// assert_eq!(format!("{}", lab), "Lab(54.62, 81.55, 42.92)");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LCHab<T, W = D65>
 where
     T: FloatNumber,

--- a/crates/auto-palette/src/color/lchuv.rs
+++ b/crates/auto-palette/src/color/lchuv.rs
@@ -31,7 +31,7 @@ use crate::{
 /// let luv: Luv<_> = (&lchuv).into();
 /// assert_eq!(format!("{}", luv), "Luv(56.23, -46.00, 21.73)");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LCHuv<T, W = D65>
 where
     T: FloatNumber,

--- a/crates/auto-palette/src/color/luv.rs
+++ b/crates/auto-palette/src/color/luv.rs
@@ -31,7 +31,7 @@ use crate::{
 /// let lchuv: LCHuv<_> = (&luv).into();
 /// assert_eq!(format!("{}", lchuv), "LCH(uv)(53.64, 167.62, 8.29)");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Luv<T, W = D65>
 where
     T: FloatNumber,

--- a/crates/auto-palette/src/color/mod.rs
+++ b/crates/auto-palette/src/color/mod.rs
@@ -66,7 +66,7 @@ use crate::math::FloatNumber;
 /// let lab = color.to_lab();
 /// assert_eq!(format!("{}", lab), "Lab(52.92, 13.59, -60.47)");
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Color<T, W = D65>
 where
     T: FloatNumber,

--- a/crates/auto-palette/src/color/oklab.rs
+++ b/crates/auto-palette/src/color/oklab.rs
@@ -28,7 +28,7 @@ use crate::{
 /// let xyz: XYZ<_> = (&oklab).into();
 /// assert_eq!(format!("{}", xyz), "XYZ(0.15, 0.24, 0.20)");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Oklab<T>
 where
     T: FloatNumber,

--- a/crates/auto-palette/src/color/oklch.rs
+++ b/crates/auto-palette/src/color/oklch.rs
@@ -30,7 +30,7 @@ use crate::{
 /// let oklab: Oklab<_> = (&oklch).into();
 /// assert_eq!(format!("{}", oklab), "Oklab(0.61, -0.12, 0.03)");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Oklch<T>
 where
     T: FloatNumber,

--- a/crates/auto-palette/src/color/rgb.rs
+++ b/crates/auto-palette/src/color/rgb.rs
@@ -31,7 +31,7 @@ use crate::{
 /// let xyz: XYZ<f32> = (&rgb).into();
 /// assert_eq!(format!("{}", xyz), "XYZ(0.42, 0.22, 0.07)");
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RGB {
     pub r: u8,
     pub g: u8,

--- a/crates/auto-palette/src/color/xyz.rs
+++ b/crates/auto-palette/src/color/xyz.rs
@@ -34,7 +34,7 @@ use crate::{
 /// let oklab: Oklab<_> = (&xyz).into();
 /// assert_eq!(format!("{}", oklab), "Oklab(0.70, 0.27, -0.17)");
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XYZ<T>
 where
     T: FloatNumber,


### PR DESCRIPTION
## Description

This pull request removes the dependency on the `colored` crate and introduces a custom implementation for terminal styling.  
The new implementation supports multiple styles and color types, including 4-bit ANSI, 8-bit ANSI, 24-bit true color, and no color.

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
