### PR TITLE
Add support for 'text' and 'table' output formats in auto-palette CLI

### DIFF
--- a/crates/auto-palette-cli/src/args.rs
+++ b/crates/auto-palette-cli/src/args.rs
@@ -4,7 +4,7 @@ use auto_palette::{color::Color, Algorithm, FloatNumber, Theme};
 use clap::{crate_authors, crate_description, crate_version, Parser, ValueEnum, ValueHint};
 
 /// The command line options for the `auto-palette` command.
-#[derive(Debug, Parser)]
+#[derive(Debug, PartialEq, Eq, Parser)]
 #[command(
     name = "auto-palette",
     bin_name = "auto-palette",
@@ -59,10 +59,21 @@ pub struct Options {
         value_name = "name",
         value_enum,
         help = "Output color space for the extracted colors",
-        default_value_t = ColorOption::default(),
+        default_value_t = ColorFormat::default(),
         ignore_case = true,
     )]
-    pub color: ColorOption,
+    pub color: ColorFormat,
+
+    #[arg(
+        long,
+        short = 'o',
+        value_name = "name",
+        value_enum,
+        help = "Output format for the extracted colors",
+        default_value_t = OutputFormat::default(),
+        ignore_case = true,
+    )]
+    pub output: OutputFormat,
 
     #[arg(
         long,
@@ -73,7 +84,7 @@ pub struct Options {
 }
 
 /// The algorithm options for extracting the color palette from the image.
-#[derive(Debug, Default, Copy, Clone, ValueEnum)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, ValueEnum)]
 pub enum AlgorithmOption {
     #[default]
     #[clap(
@@ -104,7 +115,7 @@ impl From<AlgorithmOption> for Algorithm {
 }
 
 /// The theme options for selecting the swatches from the extracted color palette.
-#[derive(Debug, Copy, Clone, ValueEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum)]
 pub enum ThemeOption {
     #[clap(
         name = "basic",
@@ -134,8 +145,8 @@ impl From<ThemeOption> for Theme {
 }
 
 /// The color space options for the extracted colors.
-#[derive(Debug, Default, Copy, Clone, ValueEnum)]
-pub enum ColorOption {
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, ValueEnum)]
+pub enum ColorFormat {
     #[default]
     #[clap(name = "hex", help = "Hexadecimal color representation")]
     Hex,
@@ -161,7 +172,7 @@ pub enum ColorOption {
     Xyz,
 }
 
-impl ColorOption {
+impl ColorFormat {
     /// Returns the string representation of the color space for the given color.
     ///
     /// # Arguments
@@ -174,7 +185,7 @@ impl ColorOption {
     where
         T: FloatNumber,
     {
-        match self {
+        match *self {
             Self::Hex => color.to_hex_string(),
             Self::Rgb => color.to_rgb().to_string(),
             Self::Hsl => color.to_hsl().to_string(),
@@ -188,4 +199,13 @@ impl ColorOption {
             Self::Xyz => color.to_xyz().to_string(),
         }
     }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    #[default]
+    #[clap(name = "text", help = "Text output format")]
+    Text,
+    #[clap(name = "table", help = "Table output format")]
+    Table,
 }

--- a/crates/auto-palette-cli/src/context.rs
+++ b/crates/auto-palette-cli/src/context.rs
@@ -1,0 +1,41 @@
+use crate::{args::Options, env::Env};
+
+/// The context for the command line application.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Context {
+    args: Options,
+    env: Env,
+}
+
+impl Context {
+    /// Creates a new `Context` instance with the given arguments.
+    ///
+    /// # Arguments
+    /// * `args` - The command line arguments.
+    /// * `env` - The environment variables.
+    ///
+    /// # Returns
+    /// A new `Context` instance.
+    #[must_use]
+    pub fn new(args: Options, env: Env) -> Self {
+        Self { args, env }
+    }
+
+    /// Returns the command line arguments.
+    ///
+    /// # Returns
+    /// The command line arguments.
+    #[must_use]
+    pub fn args(&self) -> &Options {
+        &self.args
+    }
+
+    /// Returns the environment variables.
+    ///
+    /// # Returns
+    /// The environment variables.
+    #[must_use]
+    pub fn env(&self) -> &Env {
+        &self.env
+    }
+}

--- a/crates/auto-palette-cli/src/env.rs
+++ b/crates/auto-palette-cli/src/env.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 /// The environment variables.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Env {
     pub colorterm: Option<String>,
     pub no_color: Option<String>,

--- a/crates/auto-palette-cli/src/output.rs
+++ b/crates/auto-palette-cli/src/output.rs
@@ -1,0 +1,114 @@
+use std::io::{BufWriter, Error, Write};
+
+use crate::table::Table;
+
+/// The trait for printing the swatches.
+pub trait Printer {
+    /// Prints the table.
+    ///
+    /// # Arguments
+    /// * `table` - The table to print.
+    /// * `out` - The output writer.
+    ///
+    /// # Returns
+    /// The result of the printing.
+    fn print<W>(&self, table: &Table, out: &mut W) -> Result<(), Error>
+    where
+        W: Write;
+}
+
+/// The printer for printing the swatches in the text format.
+#[derive(Debug)]
+pub struct TextPrinter;
+
+impl Printer for TextPrinter {
+    fn print<W>(&self, table: &Table, out: &mut W) -> Result<(), Error>
+    where
+        W: Write,
+    {
+        let columns = table.columns();
+        if columns.is_empty() {
+            return Ok(());
+        }
+
+        let mut writer = BufWriter::new(out);
+        let count = columns[0].rows().len();
+        for i in 0..count {
+            for column in columns {
+                write!(
+                    writer,
+                    "{:width$} ",
+                    column.rows()[i],
+                    width = column.width()
+                )?;
+            }
+            writeln!(writer)?;
+        }
+        writer.flush()
+    }
+}
+
+/// The printer for printing the swatches in the table format.
+#[derive(Debug)]
+pub struct TablePrinter;
+
+impl Printer for TablePrinter {
+    fn print<W>(&self, table: &Table, out: &mut W) -> Result<(), Error>
+    where
+        W: Write,
+    {
+        let columns = table.columns();
+        if columns.is_empty() {
+            return Ok(());
+        }
+
+        let mut writer = BufWriter::new(out);
+        for column in columns {
+            write!(writer, "+")?;
+            for _ in 0..column.width() + 2 {
+                write!(writer, "-")?;
+            }
+        }
+        writeln!(writer, "+")?;
+
+        for column in columns {
+            write!(
+                writer,
+                "| {:width$} ",
+                column.name(),
+                width = column.width()
+            )?;
+        }
+        writeln!(writer, "|")?;
+
+        for column in columns {
+            write!(writer, "+")?;
+            for _ in 0..column.width() + 2 {
+                write!(writer, "-")?;
+            }
+        }
+        writeln!(writer, "+")?;
+
+        let count = columns[0].rows().len();
+        for i in 0..count {
+            for column in columns {
+                write!(
+                    writer,
+                    "| {:width$} ",
+                    column.rows()[i],
+                    width = column.width()
+                )?;
+            }
+            writeln!(writer, "|")?;
+        }
+
+        for column in columns {
+            write!(writer, "+")?;
+            for _ in 0..column.width() + 2 {
+                write!(writer, "-")?;
+            }
+        }
+        writeln!(writer, "+")?;
+        writer.flush()
+    }
+}

--- a/crates/auto-palette-cli/src/table.rs
+++ b/crates/auto-palette-cli/src/table.rs
@@ -1,0 +1,130 @@
+use std::fmt::Display;
+
+/// The column representation for the table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Column {
+    name: String,
+    rows: Vec<String>,
+    width: usize,
+}
+
+impl Column {
+    /// Creates a new `Column` instance with the given heading.
+    ///
+    /// # Arguments
+    /// * `name` - The name of the column.
+    ///
+    /// # Returns
+    /// A new `Column` instance.
+    pub fn new<T>(name: T) -> Self
+    where
+        T: AsRef<str>,
+    {
+        let name = name.as_ref();
+        Self {
+            name: name.to_string(),
+            rows: vec![],
+            width: name.len(),
+        }
+    }
+
+    /// Returns the width of the column.
+    ///
+    /// # Returns
+    /// The width of the column.
+    #[inline]
+    #[must_use]
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Returns the name of the column.
+    ///
+    /// # Returns
+    /// The name of the column.
+    #[inline]
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the rows of the column.
+    ///
+    /// # Returns
+    /// The rows of the column.
+    #[inline]
+    #[must_use]
+    pub fn rows(&self) -> &[String] {
+        &self.rows
+    }
+
+    /// Adds a row to the column.
+    ///
+    /// # Type Parameters
+    /// * `T` - The type of the row.
+    ///
+    /// # Arguments
+    /// * `row` - The row to add.
+    pub fn add_row<T>(&mut self, row: T) -> &mut Self
+    where
+        T: AsRef<str> + Display,
+    {
+        let string = format!("{}", row);
+        self.width = self.width.max(string.len());
+        self.rows.push(string);
+        self
+    }
+}
+
+/// The table representation.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Table {
+    columns: Vec<Column>,
+}
+
+impl Table {
+    /// Creates a new `Table` instance.
+    ///
+    /// # Returns
+    /// A new `Table` instance.
+    pub fn new() -> Self {
+        Self { columns: vec![] }
+    }
+
+    /// Returns the columns of the table.
+    ///
+    /// # Returns
+    /// The columns of the table.
+    #[must_use]
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    /// Adds a column to the table with the given name.
+    ///
+    /// # Arguments
+    /// * `name` - The name of the column.
+    pub fn add_column<T>(&mut self, name: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.columns.push(Column::new(name));
+        self
+    }
+
+    /// Adds a row to the table.
+    ///
+    /// # Type Parameters
+    /// * `T` - The type of the row.
+    ///
+    /// # Arguments
+    /// * `row` - The row to add.
+    pub fn add_row<T>(&mut self, row: &[T])
+    where
+        T: AsRef<str> + Display,
+    {
+        for (column, value) in self.columns.iter_mut().zip(row.iter()) {
+            column.add_row(value);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This pull request introduces the ability to output the results in two formats `text` and `table`. The `text` format outputs the swatches in a simple text list, while the `table` format presents the swatches in a more structured table layout.   
This enhancement provides users with more flexibility in how they view the results.

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
