### PR TITLE
Add support for 'json' output formats in auto-palette CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ predicates               = "3.1.0"
 rand                     = { version = "0.8.5", default-features = false, features = ["std_rng"] }
 rand_distr               = "0.4.3"
 reqwest                  = { version = "0.12.4", features = ["blocking"] }
-rstest                   = "0.19.0"
+rstest                   = "0.21.0"
+serde_json               = "1.0.117"
 wasm-bindgen-test        = "0.3.42"
 console_error_panic_hook = "0.1.7"
 js-sys                   = "0.3.69"

--- a/crates/auto-palette-cli/Cargo.toml
+++ b/crates/auto-palette-cli/Cargo.toml
@@ -22,6 +22,7 @@ rust-version = "1.75.0"
 auto-palette = { workspace = true, features = ["image"] }
 clap         = { workspace = true, features = ["derive"] }
 image        = { workspace = true }
+serde_json   = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/auto-palette-cli/src/args.rs
+++ b/crates/auto-palette-cli/src/args.rs
@@ -5,7 +5,7 @@ use clap::{crate_authors, crate_description, crate_version, Parser, ValueEnum, V
 
 use crate::{
     context::Context,
-    output::{Printer, TablePrinter, TextPrinter},
+    output::{JsonPrinter, Printer, TablePrinter, TextPrinter},
 };
 
 /// The command line options for the `auto-palette` command.
@@ -208,6 +208,8 @@ impl ColorFormat {
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, ValueEnum)]
 pub enum OutputFormat {
+    #[clap(name = "json", help = "JSON output format")]
+    Json,
     #[default]
     #[clap(name = "text", help = "Text output format")]
     Text,
@@ -229,6 +231,7 @@ impl OutputFormat {
         T: FloatNumber,
     {
         match *self {
+            OutputFormat::Json => JsonPrinter::new(context).print(swatches, &mut std::io::stdout()),
             OutputFormat::Text => TextPrinter::new(context).print(swatches, &mut std::io::stdout()),
             OutputFormat::Table => {
                 TablePrinter::new(context).print(swatches, &mut std::io::stdout())

--- a/crates/auto-palette-cli/src/output/json.rs
+++ b/crates/auto-palette-cli/src/output/json.rs
@@ -1,0 +1,84 @@
+use std::io::{BufWriter, Error, Write};
+
+use auto_palette::{FloatNumber, Swatch};
+use serde_json::{Map, Value};
+
+use crate::{context::Context, output::Printer};
+
+const KEY_SWATCHES: &str = "swatches";
+const KEY_COLOR: &str = "color";
+const KEY_POSITION: &str = "position";
+const KEY_POSITION_X: &str = "x";
+const KEY_POSITION_Y: &str = "y";
+const KEY_POPULATION: &str = "population";
+
+/// The JSON printer for printing the swatches.
+#[derive(Debug)]
+pub struct JsonPrinter<'a> {
+    context: &'a Context,
+}
+
+impl<'a> JsonPrinter<'a> {
+    /// Creates a new `JsonPrinter` instance.
+    ///
+    /// # Arguments
+    /// * `context` - The context of the application.
+    ///
+    /// # Returns
+    /// A new `JsonPrinter` instance.
+    pub fn new(context: &'a Context) -> Self {
+        Self { context }
+    }
+
+    #[inline]
+    #[must_use]
+    fn swatch_to_json<T>(&self, swatch: &Swatch<T>) -> Value
+    where
+        T: FloatNumber,
+    {
+        let mut swatch_map = Map::with_capacity(3);
+
+        let color_format = self.context.args().color;
+        let color = color_format.fmt(swatch.color());
+        swatch_map.insert(KEY_COLOR.into(), Value::String(color));
+
+        swatch_map.insert(KEY_POSITION.into(), {
+            let mut position_map = Map::with_capacity(2);
+            let (x, y) = swatch.position();
+            position_map.insert(KEY_POSITION_X.into(), Value::Number(x.into()));
+            position_map.insert(KEY_POSITION_Y.into(), Value::Number(y.into()));
+            Value::Object(position_map)
+        });
+
+        let population = swatch.population();
+        swatch_map.insert(KEY_POPULATION.into(), Value::Number(population.into()));
+        Value::Object(swatch_map)
+    }
+}
+
+impl<'a> Printer for JsonPrinter<'a> {
+    fn print<T, W>(&self, swatches: &[Swatch<T>], output: &mut W) -> Result<(), Error>
+    where
+        T: FloatNumber,
+        W: Write,
+    {
+        let swatch_array = Value::Array(
+            swatches
+                .iter()
+                .map(|swatch| self.swatch_to_json(swatch))
+                .collect::<Vec<_>>(),
+        );
+
+        let root_object = Value::Object({
+            let mut result_map = Map::with_capacity(1);
+            result_map.insert(KEY_SWATCHES.into(), swatch_array);
+            result_map
+        });
+
+        let mut writer = BufWriter::new(output);
+        let json_str = serde_json::to_string_pretty(&root_object)?;
+        writeln!(writer, "{}", json_str)?;
+        writer.flush()?;
+        Ok(())
+    }
+}

--- a/crates/auto-palette-cli/src/output/mod.rs
+++ b/crates/auto-palette-cli/src/output/mod.rs
@@ -1,7 +1,9 @@
+mod json;
 mod printer;
 mod table;
 mod text;
 
+pub use json::JsonPrinter;
 pub use printer::Printer;
 pub use table::TablePrinter;
 pub use text::TextPrinter;


### PR DESCRIPTION
## Description

This pull request introduces the ability to output the results in 'json'. The 'json' format outputs the swatches in a simple JSON string.
This enhancement provides users with more flexibility in how they view the results.

## Related Issue

https://github.com/t28hub/auto-palette/pull/63

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
