### PR TITLE
Improve Theme enum algorithms to consider image ratio

### DIFF
--- a/crates/auto-palette-cli/src/args.rs
+++ b/crates/auto-palette-cli/src/args.rs
@@ -124,9 +124,11 @@ impl From<AlgorithmOption> for Algorithm {
 pub enum ThemeOption {
     #[clap(
         name = "basic",
-        help = "A general-purpose theme suitable for a wide range of images."
+        help = "Prioritize high population swatches. Ideal for selecting the most common colors."
     )]
     Basic,
+    #[clap(name = "colorful", help = "Prioritize colorful colors.")]
+    Colorful,
     #[clap(name = "vivid", help = "Prioritize saturated colors.")]
     Vivid,
     #[clap(name = "muted", help = "Prioritize desaturated colors.")]
@@ -141,6 +143,7 @@ impl From<ThemeOption> for Theme {
     fn from(option: ThemeOption) -> Self {
         match option {
             ThemeOption::Basic => Theme::Basic,
+            ThemeOption::Colorful => Theme::Colorful,
             ThemeOption::Vivid => Theme::Vivid,
             ThemeOption::Muted => Theme::Muted,
             ThemeOption::Light => Theme::Light,

--- a/crates/auto-palette-wasm/src/swatch.rs
+++ b/crates/auto-palette-wasm/src/swatch.rs
@@ -56,7 +56,7 @@ mod tests {
     fn test_color() {
         // Arrange
         let color = Color::from_str("#149972").unwrap();
-        let swatch = Swatch::new(color.clone(), (128, 32), 384);
+        let swatch = Swatch::new(color.clone(), (128, 32), 384, 0.25);
         let wrapper = SwatchWrapper(swatch);
 
         // Act
@@ -69,7 +69,7 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_position() {
         let color = Color::from_str("#149972").unwrap();
-        let swatch = Swatch::new(color.clone(), (128, 32), 384);
+        let swatch = Swatch::new(color.clone(), (128, 32), 384, 0.25);
         let wrapper = SwatchWrapper(swatch);
 
         // Act
@@ -83,7 +83,7 @@ mod tests {
     fn test_population() {
         // Arrange
         let color = Color::from_str("#149972").unwrap();
-        let swatch = Swatch::new(color, (128, 32), 384);
+        let swatch = Swatch::new(color, (128, 32), 384, 0.25);
         let wrapper = SwatchWrapper(swatch);
 
         // Act

--- a/crates/auto-palette-wasm/src/theme.rs
+++ b/crates/auto-palette-wasm/src/theme.rs
@@ -35,6 +35,8 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[rstest]
+    #[case::basic("basic", Theme::Basic)]
+    #[case::colorful("colorful", Theme::Colorful)]
     #[case::vivid("vivid", Theme::Vivid)]
     #[case::muted("muted", Theme::Muted)]
     #[case::light("light", Theme::Light)]

--- a/crates/auto-palette/src/swatch.rs
+++ b/crates/auto-palette/src/swatch.rs
@@ -28,6 +28,7 @@ where
     color: Color<T>,
     position: (u32, u32),
     population: usize,
+    ratio: T,
 }
 
 impl<T> Swatch<T>
@@ -40,14 +41,17 @@ where
     /// * `color` - The color of the swatch.
     /// * `position` - The position of the swatch.
     /// * `population` - The population of the swatch.
+    /// * `ratio` - The ratio of the swatch to the total population.
+    ///
     ///
     /// # Returns
     /// A new `Swatch` instance.
-    pub fn new(color: Color<T>, position: (u32, u32), population: usize) -> Self {
+    pub fn new(color: Color<T>, position: (u32, u32), population: usize, ratio: T) -> Self {
         Self {
             color,
             position,
             population,
+            ratio,
         }
     }
 
@@ -55,6 +59,7 @@ where
     ///
     /// # Returns
     /// The color of this swatch.
+    #[inline]
     #[must_use]
     pub fn color(&self) -> &Color<T> {
         &self.color
@@ -65,6 +70,7 @@ where
     /// # Returns
     /// The position of this swatch.
     /// The position is a tuple of the x and y coordinates.
+    #[inline]
     #[must_use]
     pub fn position(&self) -> (u32, u32) {
         self.position
@@ -74,9 +80,20 @@ where
     ///
     /// # Returns
     /// The population of this swatch.
+    #[inline]
     #[must_use]
     pub fn population(&self) -> usize {
         self.population
+    }
+
+    /// Returns the ratio of this swatch to the total population.
+    ///
+    /// # Returns
+    /// The ratio of this swatch to the total population.
+    #[inline]
+    #[must_use]
+    pub fn ratio(&self) -> T {
+        self.ratio
     }
 }
 
@@ -88,7 +105,7 @@ mod tests {
     fn test_new_swatch() {
         // Act
         let color = Color::new(80.0, 0.0, 0.0);
-        let swatch = Swatch::new(color.clone(), (5, 10), 384);
+        let swatch = Swatch::new(color.clone(), (5, 10), 384, 0.25);
 
         // Assert
         assert_eq!(swatch.color(), &color);


### PR DESCRIPTION
## Description

This pull request improves the algorithm in the `Theme` enum to consider the ratio of the image.  
It also add `Colorful` theme and refactors the internal implementation of `Basic` theme to simplify the swatch selection algorithm.

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
