### PR TITLE
Implement CMYK color model conversion functionality

### DIFF
--- a/crates/auto-palette-cli/src/args.rs
+++ b/crates/auto-palette-cli/src/args.rs
@@ -160,6 +160,8 @@ pub enum ColorFormat {
     Hex,
     #[clap(name = "rgb", help = "RGB color space")]
     Rgb,
+    #[clap(name = "cmyk", help = "CMYK color space")]
+    Cmyk,
     #[clap(name = "hsl", help = "HSL color space")]
     Hsl,
     #[clap(name = "hsv", help = "HSV color space")]
@@ -196,6 +198,7 @@ impl ColorFormat {
         match *self {
             Self::Hex => color.to_hex_string(),
             Self::Rgb => color.to_rgb().to_string(),
+            Self::Cmyk => color.to_cmyk().to_string(),
             Self::Hsl => color.to_hsl().to_string(),
             Self::Hsv => color.to_hsv().to_string(),
             Self::Lab => color.to_lab().to_string(),

--- a/crates/auto-palette/src/color/cmyk.rs
+++ b/crates/auto-palette/src/color/cmyk.rs
@@ -1,0 +1,170 @@
+use std::fmt::{Display, Formatter};
+
+use num_traits::clamp;
+
+use crate::{color::RGB, FloatNumber};
+
+/// The CMYK color representation.
+///
+/// See the following for more details:
+/// [CMYK color model - Wikipedia](https://en.wikipedia.org/wiki/CMYK_color_model)
+///
+/// # Type Parameters
+/// * `T` - The floating point type.
+///
+/// # Fields
+/// * `c` - The cyan component.
+/// * `m` - The magenta component.
+/// * `y` - The yellow component.
+/// * `k` - The key (black) component.
+///
+/// # Examples
+/// ```
+/// use auto_palette::color::{CMYK, RGB};
+///
+/// let rgb = RGB::new(255, 255, 0);
+/// let cmyk = CMYK::<f32>::from(&rgb);
+/// assert_eq!(format!("{}", cmyk), "CMYK(0.00, 0.00, 1.00, 0.00)");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CMYK<T>
+where
+    T: FloatNumber,
+{
+    pub c: T,
+    pub m: T,
+    pub y: T,
+    pub k: T,
+}
+
+impl<T> CMYK<T>
+where
+    T: FloatNumber,
+{
+    /// Creates a new `CMYK` instance.
+    ///
+    /// # Arguments
+    /// * `c` - The cyan component.
+    /// * `m` - The magenta component.
+    /// * `y` - The yellow component.
+    /// * `k` - The key (black) component.
+    ///
+    /// # Returns
+    /// A new `CMYK` instance.
+    #[must_use]
+    pub fn new(c: T, m: T, y: T, k: T) -> Self {
+        Self {
+            c: clamp(c, T::zero(), T::one()),
+            m: clamp(m, T::zero(), T::one()),
+            y: clamp(y, T::zero(), T::one()),
+            k: clamp(k, T::zero(), T::one()),
+        }
+    }
+}
+
+impl<T> Display for CMYK<T>
+where
+    T: FloatNumber,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CMYK({:.2}, {:.2}, {:.2}, {:.2})",
+            self.c, self.m, self.y, self.k
+        )
+    }
+}
+
+impl<T> From<&RGB> for CMYK<T>
+where
+    T: FloatNumber,
+{
+    fn from(rgb: &RGB) -> Self {
+        let max = RGB::max_value::<T>();
+        let r = T::from_u8(rgb.r) / max;
+        let g = T::from_u8(rgb.g) / max;
+        let b = T::from_u8(rgb.b) / max;
+
+        let k = T::one() - r.max(g).max(b);
+        if k.is_one() {
+            CMYK::new(T::zero(), T::zero(), T::zero(), k)
+        } else {
+            let denominator = T::one() - k;
+            let c = (T::one() - r - k) / denominator;
+            let m = (T::one() - g - k) / denominator;
+            let y = (T::one() - b - k) / denominator;
+            CMYK::new(c, m, y, k)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        // Act
+        let actual = CMYK::new(1.00, 0.75, 0.50, 0.25);
+
+        // Assert
+        assert_eq!(
+            actual,
+            CMYK {
+                c: 1.00,
+                m: 0.75,
+                y: 0.50,
+                k: 0.25,
+            }
+        );
+    }
+
+    #[rstest]
+    #[case((-0.01, -0.02, -0.03, -0.04), (0.00, 0.00, 0.00, 0.00))]
+    #[case((1.01, 1.02, 1.03, 1.04), (1.00, 1.00, 1.00, 1.00))]
+    fn test_new_clamp(#[case] input: (f32, f32, f32, f32), #[case] expected: (f32, f32, f32, f32)) {
+        // Act
+        let (c, m, y, k) = input;
+        let actual = CMYK::new(c, m, y, k);
+
+        // Assert
+        assert_eq!(
+            actual,
+            CMYK {
+                c: expected.0,
+                m: expected.1,
+                y: expected.2,
+                k: expected.3,
+            }
+        );
+    }
+
+    #[test]
+    fn test_fmt() {
+        // Act
+        let cmyk = CMYK::new(0.00, 0.00, 1.00, 0.00);
+        let actual = format!("{}", cmyk);
+
+        // Assert
+        assert_eq!("CMYK(0.00, 0.00, 1.00, 0.00)", actual);
+    }
+
+    #[rstest]
+    #[case::black(RGB::new(0, 0, 0), CMYK::new(0.00, 0.00, 0.00, 1.00))]
+    #[case::white(RGB::new(255, 255, 255), CMYK::new(0.00, 0.00, 0.00, 0.00))]
+    #[case::red(RGB::new(255, 0, 0), CMYK::new(0.00, 1.00, 1.00, 0.00))]
+    #[case::green(RGB::new(0, 255, 0), CMYK::new(1.00, 0.00, 1.00, 0.00))]
+    #[case::blue(RGB::new(0, 0, 255), CMYK::new(1.00, 1.00, 0.00, 0.00))]
+    #[case::yellow(RGB::new(255, 255, 0), CMYK::new(0.00, 0.00, 1.00, 0.00))]
+    #[case::cyan(RGB::new(0, 255, 255), CMYK::new(1.00, 0.00, 0.00, 0.00))]
+    #[case::magenta(RGB::new(255, 0, 255), CMYK::new(0.00, 1.00, 0.00, 0.00))]
+    fn test_from_rgb(#[case] rgb: RGB, #[case] expected: CMYK<f32>) {
+        // Act
+        let actual = CMYK::from(&rgb);
+
+        // Assert
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/auto-palette/src/color/mod.rs
+++ b/crates/auto-palette/src/color/mod.rs
@@ -1,5 +1,6 @@
 mod ansi16;
 mod ansi256;
+mod cmyk;
 mod hsl;
 mod hsv;
 mod hue;
@@ -22,6 +23,7 @@ use std::{
 
 pub use ansi16::Ansi16;
 pub use ansi256::Ansi256;
+pub use cmyk::CMYK;
 pub use hsl::HSL;
 pub use hsv::HSV;
 pub use hue::Hue;
@@ -205,6 +207,16 @@ where
     pub fn to_rgb(&self) -> RGB {
         let xyz = self.to_xyz();
         RGB::from(&xyz)
+    }
+
+    /// Converts this color to the CMYK color space.
+    ///
+    /// # Returns
+    /// The converted `CMYK` color.
+    #[must_use]
+    pub fn to_cmyk(&self) -> CMYK<T> {
+        let rgb = self.to_rgb();
+        CMYK::from(&rgb)
     }
 
     /// Converts this color to the HSL color space.
@@ -451,9 +463,17 @@ mod tests {
         let actual = color.to_rgb();
 
         // Assert
-        assert_eq!(actual.r, 0);
-        assert_eq!(actual.g, 255);
-        assert_eq!(actual.b, 255);
+        assert_eq!(actual, RGB::new(0, 255, 255));
+    }
+
+    #[test]
+    fn test_to_cmyk() {
+        // Act
+        let color: Color<f32> = Color::new(91.1120, -48.0806, -14.1521);
+        let actual = color.to_cmyk();
+
+        // Assert
+        assert_eq!(actual, CMYK::new(1.0, 0.0, 0.0, 0.0));
     }
 
     #[test]


### PR DESCRIPTION
## Description

This pull request introduces support for color conversion to the `CMYK` color model in the auto-palette project.  
The changes include the addition of a new `CMYK` struct in the `color` module and the implementation of the `From<&RGB>` trait for `CMYK`. This allows for the conversion of colors from the `RGB` color space to the `CMYK` color space.

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
