### PR TITLE
Improve scoring fomula and conditions for swatches in Theme

### DIFF
--- a/crates/auto-palette/src/math/number.rs
+++ b/crates/auto-palette/src/math/number.rs
@@ -35,6 +35,16 @@ pub trait FloatNumber:
     #[must_use]
     fn from_u8(value: u8) -> Self;
 
+    /// Creates a new floating point number from a `u16`.
+    ///
+    /// # Arguments
+    /// * `value` - The value to convert.
+    ///
+    /// # Returns
+    /// The floating point number.
+    #[must_use]
+    fn from_u16(value: u16) -> Self;
+
     /// Creates a new floating point number from a `u32`.
     ///
     /// # Arguments
@@ -106,6 +116,12 @@ impl FloatNumber for f32 {
 
     #[inline]
     #[must_use]
+    fn from_u16(value: u16) -> Self {
+        value as f32
+    }
+
+    #[inline]
+    #[must_use]
     fn from_u32(value: u32) -> Self {
         value as f32
     }
@@ -151,6 +167,12 @@ impl FloatNumber for f64 {
     #[inline]
     #[must_use]
     fn from_u8(value: u8) -> Self {
+        value as f64
+    }
+
+    #[inline]
+    #[must_use]
+    fn from_u16(value: u16) -> Self {
         value as f64
     }
 
@@ -256,6 +278,7 @@ mod tests {
     #[test]
     fn test_float_number_f32() {
         assert_eq!(f32::from_u8(128), 128.0);
+        assert_eq!(f32::from_u16(256), 256.0);
         assert_eq!(f32::from_u32(1024), 1024.0);
         assert_eq!(f32::from_usize(4096), 4096.0);
         assert_eq!(f32::from_f32(0.5), 0.5);
@@ -268,6 +291,7 @@ mod tests {
     #[test]
     fn test_float_number_f64() {
         assert_eq!(f64::from_u8(128), 128.0);
+        assert_eq!(f64::from_u16(256), 256.0);
         assert_eq!(f64::from_u32(1024), 1024.0);
         assert_eq!(f64::from_usize(4096), 4096.0);
         assert_eq!(f64::from_f32(0.5), 0.5);

--- a/crates/auto-palette/src/palette.rs
+++ b/crates/auto-palette/src/palette.rs
@@ -463,7 +463,7 @@ mod tests {
     #[case::basic(Theme::Basic, vec ! ["#FFFFFF", "#000000"])]
     #[case::colorful(Theme::Colorful, vec ! ["#0081C8", "#FCB131"])]
     #[case::vivid(Theme::Vivid, vec ! ["#EE334E", "#00A651"])]
-    #[case::muted(Theme::Muted, vec ! ["#FFFFFF", "#000000"])]
+    #[case::muted(Theme::Muted, vec ! ["#0081C8", "#000000"])]
     #[case::light(Theme::Light, vec ! ["#FFFFFF", "#FCB131"])]
     #[case::dark(Theme::Dark, vec ! ["#FFFFFF", "#000000"])]
     fn test_find_swatches_with_theme(#[case] theme: Theme, #[case] expected: Vec<&str>) {


### PR DESCRIPTION
## Description

This pull request refines the scoring formula and conditions for swatches in the `Theme` enum.  
The changes aim to improve the color selection for each theme.

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
