### PR TITLE
Fix deprecated 'trailingComma' option in biome.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.7.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.8.2/schema.json",
   "files": {
     "ignoreUnknown": true,
     "include": ["**/*.js", "**/*.ts", "**/*.json"],
@@ -25,7 +25,7 @@
       "quoteStyle": "single",
       "jsxQuoteStyle": "single",
       "quoteProperties": "asNeeded",
-      "trailingComma": "all",
+      "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
       "indentStyle": "space",


### PR DESCRIPTION
## Description

In this pull request, the deprecated 'javascript.formatter.trailingComma' option was updated to the new 'javascript.formatter.trailingCommas' option in the `biome.json` configuration file.

- [`javascript.formatter.trailingComma`](https://biomejs.dev/reference/configuration/#javascriptformattertrailingcomma)
- [`javascript.formatter.trailingCommas`](https://biomejs.dev/reference/configuration/#javascriptformattertrailingcommas)

## Related Issue

No related issue.

## Type of Change

- [ ] Documentation update / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
