### PR TITLE
Implement Serialize for color space structs for wasm feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ predicates               = "3.1.0"
 rand                     = "0.9.0"
 rand_distr               = "0.5.0"
 rstest                   = "0.24.0"
+serde                    = { version = "1.0.117", features = ["derive"] }
 serde_json               = "1.0.117"
+serde_test               = "1.0.117"
 wasm-bindgen-test        = "0.3.50"
 console_error_panic_hook = "0.1.7"
 wasm-bindgen             = "0.2.100"
@@ -34,4 +36,4 @@ opt-level = 3
 
 [profile.release]
 lto       = true
-opt-level = 's'
+opt-level = 'z'

--- a/crates/auto-palette-cli/Cargo.toml
+++ b/crates/auto-palette-cli/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 
 # `cargo msrv` does not support `rust-version.workspace` yet.
 # https://github.com/foresterre/cargo-msrv/issues/590
-rust-version = "1.75.0"
+rust-version = "1.84.0"
 
 [dependencies]
 auto-palette = { workspace = true, features = ["image"] }

--- a/crates/auto-palette-wasm/Cargo.toml
+++ b/crates/auto-palette-wasm/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 
 # `cargo msrv` does not support `rust-version.workspace` yet.
 # https://github.com/foresterre/cargo-msrv/issues/590
-rust-version = "1.75.0"
+rust-version = "1.84.0"
 
 
 [lib]

--- a/crates/auto-palette/Cargo.toml
+++ b/crates/auto-palette/Cargo.toml
@@ -13,12 +13,12 @@ repository.workspace = true
 
 # `cargo msrv` does not support `rust-version.workspace` yet
 # https://github.com/foresterre/cargo-msrv/issues/590
-rust-version = "1.75.0"
+rust-version = "1.84.0"
 
 [features]
 default = ["image"]
 image   = ["dep:image"]
-wasm    = ["getrandom/wasm_js"]
+wasm    = ["getrandom/wasm_js", "dep:serde"]
 
 [dependencies]
 getrandom  = { workspace = true }
@@ -26,9 +26,11 @@ image      = { workspace = true, optional = true }
 num-traits = { workspace = true }
 rand       = { workspace = true }
 rand_distr = { workspace = true }
+serde      = { workspace = true, optional = true }
 
 [dev-dependencies]
-rstest = { workspace = true }
+rstest     = { workspace = true }
+serde_test = { workspace = true }
 
 [[example]]
 name              = "basic"

--- a/crates/auto-palette/src/color/ansi256.rs
+++ b/crates/auto-palette/src/color/ansi256.rs
@@ -3,6 +3,9 @@ use std::{
     fmt::{Display, Formatter},
 };
 
+#[cfg(feature = "wasm")]
+use serde::{Serialize, Serializer};
+
 use crate::{
     color::{Ansi16, RGB},
     FloatNumber,
@@ -47,6 +50,16 @@ impl Ansi256 {
     #[must_use]
     pub fn code(&self) -> u8 {
         self.code
+    }
+}
+
+#[cfg(feature = "wasm")]
+impl Serialize for Ansi256 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.code.serialize(serializer)
     }
 }
 
@@ -106,6 +119,7 @@ where
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use serde_test::{assert_ser_tokens, Token};
 
     use super::*;
 
@@ -120,6 +134,16 @@ mod tests {
         // Assert
         assert_eq!(actual, Ansi256 { code });
         assert_eq!(actual.code(), code);
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_serialize() {
+        // Act
+        let ansi256 = Ansi256::new(120);
+
+        // Assert
+        assert_ser_tokens(&ansi256, &[Token::U8(120)]);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/cmyk.rs
+++ b/crates/auto-palette/src/color/cmyk.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Display, Formatter};
 
 use num_traits::clamp;
+#[cfg(feature = "wasm")]
+use serde::Serialize;
 
 use crate::{color::RGB, FloatNumber};
 
@@ -27,6 +29,7 @@ use crate::{color::RGB, FloatNumber};
 /// assert_eq!(format!("{}", cmyk), "CMYK(0.00, 0.00, 1.00, 0.00)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 pub struct CMYK<T>
 where
     T: FloatNumber,
@@ -101,6 +104,7 @@ where
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use serde_test::{assert_ser_tokens, Token};
 
     use super::*;
 
@@ -139,6 +143,33 @@ mod tests {
                 k: expected.3,
             }
         );
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_serialize() {
+        // Act
+        let cmyk = CMYK::new(1.00, 0.75, 0.50, 0.25);
+
+        // Assert
+        assert_ser_tokens(
+            &cmyk,
+            &[
+                Token::Struct {
+                    name: "CMYK",
+                    len: 4,
+                },
+                Token::Str("c"),
+                Token::F64(1.00),
+                Token::Str("m"),
+                Token::F64(0.75),
+                Token::Str("y"),
+                Token::F64(0.50),
+                Token::Str("k"),
+                Token::F64(0.25),
+                Token::StructEnd,
+            ],
+        )
     }
 
     #[test]

--- a/crates/auto-palette/src/color/hsl.rs
+++ b/crates/auto-palette/src/color/hsl.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 
 use num_traits::clamp;
+#[cfg(feature = "wasm")]
+use serde::Serialize;
 
 use crate::{
     color::{hue::Hue, rgb::RGB},
@@ -29,6 +31,7 @@ use crate::{
 /// assert_eq!(format!("{}", hsl), "HSL(60.00, 1.00, 0.50)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 pub struct HSL<T>
 where
     T: FloatNumber,
@@ -107,6 +110,7 @@ where
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use serde_test::{assert_ser_tokens, Token};
 
     use super::*;
 
@@ -140,6 +144,31 @@ mod tests {
         // Assert
         let (h, s, l) = expected;
         assert_eq!(actual, HSL::new(h, s, l));
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_serialize() {
+        // Act
+        let hsl = HSL::new(150.0, 0.3, 0.6);
+
+        // Assert
+        assert_ser_tokens(
+            &hsl,
+            &[
+                Token::Struct {
+                    name: "HSL",
+                    len: 3,
+                },
+                Token::Str("h"),
+                Token::F64(150.0),
+                Token::Str("s"),
+                Token::F64(0.3),
+                Token::Str("l"),
+                Token::F64(0.6),
+                Token::StructEnd,
+            ],
+        )
     }
 
     #[test]

--- a/crates/auto-palette/src/color/hsv.rs
+++ b/crates/auto-palette/src/color/hsv.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 
 use num_traits::clamp;
+#[cfg(feature = "wasm")]
+use serde::Serialize;
 
 use crate::{
     color::{hue::Hue, RGB},
@@ -29,6 +31,7 @@ use crate::{
 /// assert_eq!(format!("{}", hsv), "HSV(60.00, 1.00, 1.00)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 pub struct HSV<T>
 where
     T: FloatNumber,
@@ -110,6 +113,7 @@ where
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use serde_test::{assert_ser_tokens, Token};
 
     use super::*;
 
@@ -143,6 +147,31 @@ mod tests {
         // Assert
         let (h, s, v) = expected;
         assert_eq!(actual, HSV::new(h, s, v));
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_serialize() {
+        // Act
+        let hsv = HSV::new(60.0, 0.75, 0.5);
+
+        // Assert
+        assert_ser_tokens(
+            &hsv,
+            &[
+                Token::Struct {
+                    name: "HSV",
+                    len: 3,
+                },
+                Token::Str("h"),
+                Token::F64(60.0),
+                Token::Str("s"),
+                Token::F64(0.75),
+                Token::Str("v"),
+                Token::F64(0.5),
+                Token::StructEnd,
+            ],
+        );
     }
 
     #[test]

--- a/crates/auto-palette/src/color/hue.rs
+++ b/crates/auto-palette/src/color/hue.rs
@@ -1,5 +1,8 @@
 use std::fmt::Display;
 
+#[cfg(feature = "wasm")]
+use serde::{Serialize, Serializer};
+
 use crate::math::FloatNumber;
 
 /// The hue component of a color.
@@ -70,6 +73,19 @@ where
     }
 }
 
+#[cfg(feature = "wasm")]
+impl<T> Serialize for Hue<T>
+where
+    T: FloatNumber + Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
 impl<T> Display for Hue<T>
 where
     T: FloatNumber,
@@ -99,6 +115,7 @@ mod tests {
     use std::f64::consts::PI;
 
     use rstest::rstest;
+    use serde_test::{assert_ser_tokens, Token};
 
     use super::*;
 
@@ -146,6 +163,16 @@ mod tests {
 
         // Assert
         assert_eq!(actual.to_degrees(), expected);
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_serialize() {
+        // Act
+        let hue = Hue::from_degrees(45.0);
+
+        // Assert
+        assert_ser_tokens(&hue, &[Token::F64(45.0)]);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/oklab.rs
+++ b/crates/auto-palette/src/color/oklab.rs
@@ -1,4 +1,6 @@
 use num_traits::clamp;
+#[cfg(feature = "wasm")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     color::{oklch::Oklch, XYZ},
@@ -29,6 +31,7 @@ use crate::{
 /// assert_eq!(format!("{}", xyz), "XYZ(0.15, 0.24, 0.20)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct Oklab<T>
 where
     T: FloatNumber,
@@ -116,6 +119,7 @@ where
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use serde_test::{assert_tokens, Token};
 
     use super::*;
 
@@ -132,6 +136,31 @@ mod tests {
                 a: -0.118,
                 b: 0.028
             }
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_serialize() {
+        // Act
+        let oklab = Oklab::new(0.607, -0.118, 0.028);
+
+        // Assert
+        assert_tokens(
+            &oklab,
+            &[
+                Token::Struct {
+                    name: "Oklab",
+                    len: 3,
+                },
+                Token::Str("l"),
+                Token::F64(0.607),
+                Token::Str("a"),
+                Token::F64(-0.118),
+                Token::Str("b"),
+                Token::F64(0.028),
+                Token::StructEnd,
+            ],
         );
     }
 

--- a/crates/auto-palette/src/color/oklch.rs
+++ b/crates/auto-palette/src/color/oklch.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 
 use num_traits::clamp;
+#[cfg(feature = "wasm")]
+use serde::Serialize;
 
 use crate::{
     color::{Hue, Oklab},
@@ -31,6 +33,7 @@ use crate::{
 /// assert_eq!(format!("{}", oklab), "Oklab(0.61, -0.12, 0.03)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 pub struct Oklch<T>
 where
     T: FloatNumber,
@@ -94,6 +97,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use serde_test::{assert_ser_tokens, Token};
+
     use super::*;
     use crate::color::Oklab;
 
@@ -111,6 +116,31 @@ mod tests {
                 h: Hue::from_degrees(166.651)
             }
         );
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_serialize() {
+        // Act
+        let oklch = Oklch::new(0.607, 0.121, 166.651);
+
+        // Assert
+        assert_ser_tokens(
+            &oklch,
+            &[
+                Token::Struct {
+                    name: "Oklch",
+                    len: 3,
+                },
+                Token::Str("l"),
+                Token::F64(0.607),
+                Token::Str("c"),
+                Token::F64(0.121),
+                Token::Str("h"),
+                Token::F64(166.651),
+                Token::StructEnd,
+            ],
+        )
     }
 
     #[test]

--- a/crates/auto-palette/src/color/rgb.rs
+++ b/crates/auto-palette/src/color/rgb.rs
@@ -1,5 +1,8 @@
 use std::{fmt, fmt::Display};
 
+#[cfg(feature = "wasm")]
+use serde::Serialize;
+
 use crate::{
     color::{hsl::HSL, xyz::XYZ, HSV},
     math::FloatNumber,
@@ -32,6 +35,7 @@ use crate::{
 /// assert_eq!(format!("{}", xyz), "XYZ(0.42, 0.22, 0.07)");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 pub struct RGB {
     pub r: u8,
     pub g: u8,
@@ -193,6 +197,7 @@ where
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use serde_test::{assert_ser_tokens, Token};
 
     use super::*;
 
@@ -205,6 +210,31 @@ mod tests {
         assert_eq!(actual.r, 255);
         assert_eq!(actual.g, 0);
         assert_eq!(actual.b, 64);
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_serialize() {
+        // Act
+        let rgb = RGB::new(255, 0, 64);
+
+        // Act
+        assert_ser_tokens(
+            &rgb,
+            &[
+                Token::Struct {
+                    name: "RGB",
+                    len: 3,
+                },
+                Token::Str("r"),
+                Token::U8(255),
+                Token::Str("g"),
+                Token::U8(0),
+                Token::Str("b"),
+                Token::U8(64),
+                Token::StructEnd,
+            ],
+        );
     }
 
     #[test]

--- a/crates/auto-palette/src/color/xyz.rs
+++ b/crates/auto-palette/src/color/xyz.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 
 use num_traits::clamp;
+#[cfg(feature = "wasm")]
+use serde::Serialize;
 
 use crate::{
     color::{lab::Lab, luv::Luv, rgb::RGB, white_point::WhitePoint, Oklab},
@@ -35,6 +37,7 @@ use crate::{
 /// assert_eq!(format!("{}", oklab), "Oklab(0.70, 0.27, -0.17)");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 pub struct XYZ<T>
 where
     T: FloatNumber,
@@ -318,6 +321,7 @@ where
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use serde_test::{assert_ser_tokens, Token};
 
     use super::*;
     use crate::color::D65;
@@ -331,6 +335,31 @@ mod tests {
         assert_eq!(actual.x, 0.5928);
         assert_eq!(actual.y, 0.2848);
         assert_eq!(actual.z, 0.9699);
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_serialize() {
+        // Act
+        let xyz = XYZ::new(0.5928, 0.2848, 0.9699);
+
+        // Assert
+        assert_ser_tokens(
+            &xyz,
+            &[
+                Token::Struct {
+                    name: "XYZ",
+                    len: 3,
+                },
+                Token::Str("x"),
+                Token::F64(0.5928),
+                Token::Str("y"),
+                Token::F64(0.2848),
+                Token::Str("z"),
+                Token::F64(0.9699),
+                Token::StructEnd,
+            ],
+        );
     }
 
     #[test]

--- a/crates/auto-palette/src/math/clustering/cluster.rs
+++ b/crates/auto-palette/src/math/clustering/cluster.rs
@@ -107,7 +107,7 @@ mod tests {
         // Assert
         assert!(actual.is_empty());
         assert_eq!(actual.len(), 0);
-        assert_eq!(actual.members().copied().collect::<Vec<_>>(), vec![]);
+        assert_eq!(actual.members().copied().collect::<Vec<usize>>(), vec![]);
         assert_eq!(actual.centroid(), &[0.0, 0.0]);
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "nightly-2024-11-17"
+channel    = "nightly-2025-01-23"
 profile    = "minimal"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Description

Implemented `Serialize` for color space structs (`RGB`, `XYZ`, `Oklab`, etc...) when the `wasm` feature is enabled. This allows these structs to be serialized to formats like JSON when compiling for WebAssembly.

## Related Issue
N/A

## Type of Change
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist
- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
