### PR TITLE
Update find_swatches_with_theme to use different sampling strategies based on theme

### DIFF
--- a/crates/auto-palette/src/algorithm.rs
+++ b/crates/auto-palette/src/algorithm.rs
@@ -12,11 +12,12 @@ use crate::{
 
 /// The clustering algorithm to use for color palette extraction.
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub enum Algorithm {
     /// K-means clustering algorithm.
     KMeans,
     /// DBSCAN clustering algorithm.
+    #[default]
     DBSCAN,
     /// DBSCAN++ clustering algorithm.
     DBSCANpp,

--- a/crates/auto-palette/src/math/sampling.rs
+++ b/crates/auto-palette/src/math/sampling.rs
@@ -20,7 +20,6 @@ where
     ///
     /// # Arguments
     /// * `Vec<T>` - The weights of the points.
-    #[allow(dead_code)]
     WeightedFarthest(Vec<T>),
     /// Diversity sampling strategy.
     /// The diversity is calculated using the scores of the points.


### PR DESCRIPTION
## Description

In this pull request, the internal implementation of the `Palette` struct's `find_swatches_with_theme` method has been updated.  
The sampling strategy now varies based on the provided theme. When `Theme::Basic` is given, diversity is prioritized, while for other themes, the theme's suitability is emphasized.

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
