### PR TITLE
Use image crate without default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ assert_cmd               = "2.0.14"
 auto-palette             = { version = "0.6.0", path = "crates/auto-palette", default-features = false }
 clap                     = { version = "4.5.4", features = ["cargo"] }
 getrandom                = "0.3.1"
-image                    = "0.25.1"
+image                    = { version = "0.25.1", default-features = false }
 num-traits               = "0.2.18"
 predicates               = "3.1.0"
 rand                     = "0.9.0"


### PR DESCRIPTION
First of all, let me thank you for your awesome crate. I came across a small necessary change while integrating it in my source tree.

## Description

Use `image` without any of its default dependencies (many image encoders and decoders). This decreases the amount of crates `auto-palette` brings in a tree by 1/3 (as of today, from 308 to 209 without tests and 213 when building tests). This is quite important when using `auto-palette` as part of a bigger source tree.

## Related Issue

## Type of Change

<!-- What type of change does this pull request introduce? Please check the one that applies. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

<!-- Please check the following items before submitting a pull request. -->

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
