### PR TITLE
Add GitHub Actions configuration to build `auto-palette-wasm` package for CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,3 +206,36 @@ jobs:
         with:
           name: auto-palette
           path: target/release/auto-palette-cli
+
+  build-wasm:
+    needs:
+      - test-wasm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        node:
+          - 22.x
+        pnpm:
+          - 10.7.1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm with ${{ matrix.pnpm }} version
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ matrix.pnpm }}
+
+      - name: Setup Node.js with ${{ matrix.node }} version
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the wasm package
+        working-directory: ./packages/auto-palette-wasm
+        run: pnpm build


### PR DESCRIPTION
## Description

This pull request adds the configuration to build the `auto-palette-wasm` package using GitHub Actions.  
It ensures that the package is built and tested in a CI/CD pipeline.

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
