### PR TITLE
Implement Swatch support in auto-palette-wasm for WebAssembly

### DIFF
--- a/crates/auto-palette-wasm/Cargo.toml
+++ b/crates/auto-palette-wasm/Cargo.toml
@@ -27,4 +27,6 @@ wasm-bindgen = { workspace = true }
 
 [dev-dependencies]
 image             = { workspace = true, features = ["jpeg", "png"] }
+indoc             = { workspace = true }
+serde_test        = { workspace = true }
 wasm-bindgen-test = { workspace = true }

--- a/crates/auto-palette-wasm/src/color.rs
+++ b/crates/auto-palette-wasm/src/color.rs
@@ -17,11 +17,11 @@ use auto_palette::color::{
     RGB,
     XYZ,
 };
-use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
+use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
 /// `JsColor` is a struct for wrapping `Color<f64>` to expose it to JavaScript.
 /// This struct is used to wrap the `Color` type from the auto-palette crate so that it can be used in JavaScript.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 #[wasm_bindgen(js_name = Color)]
 pub struct JsColor(pub(crate) Color<f64>);
 
@@ -203,9 +203,8 @@ impl JsColor {
     /// # Returns
     /// A string representing the color in hex format.
     #[wasm_bindgen(js_name = toHexString)]
-    pub fn to_hex_string(&self) -> JsValue {
-        let value = self.0.to_hex_string();
-        JsValue::from_str(&value)
+    pub fn to_hex_string(&self) -> String {
+        self.0.to_hex_string()
     }
 
     /// Creates a new `Color` instance with the given RGB integer value.
@@ -478,8 +477,7 @@ mod tests {
         let actual = color.to_hex_string();
 
         // Assert
-        assert!(actual.is_string(), "Expected a string");
-        assert_eq!(actual.as_string().unwrap(), "#FF8000");
+        assert_eq!(actual, "#FF8000");
     }
 
     #[wasm_bindgen_test]

--- a/crates/auto-palette-wasm/src/lib.rs
+++ b/crates/auto-palette-wasm/src/lib.rs
@@ -1,1 +1,3 @@
 mod color;
+mod position;
+mod swatch;

--- a/crates/auto-palette-wasm/src/position.rs
+++ b/crates/auto-palette-wasm/src/position.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+
+/// The position representation of a swatch.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Tsify)]
+#[serde(rename = "Position")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct JsPosition {
+    /// The x coordinate of the swatch.
+    pub x: u32,
+    /// The y coordinate of the swatch.
+    pub y: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn test_serialize() {
+        // Act
+        let position = JsPosition { x: 16, y: 32 };
+
+        // Assert
+        assert_ser_tokens(
+            &position,
+            &[
+                Token::Struct {
+                    name: "Position",
+                    len: 2,
+                },
+                Token::Str("x"),
+                Token::U32(16),
+                Token::Str("y"),
+                Token::U32(32),
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn test_deserialize() {
+        // Act
+        let position = JsPosition { x: 32, y: 16 };
+
+        // Assert
+        assert_de_tokens(
+            &position,
+            &[
+                Token::Struct {
+                    name: "Position",
+                    len: 2,
+                },
+                Token::Str("x"),
+                Token::U32(32),
+                Token::Str("y"),
+                Token::U32(16),
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn test_tsify() {
+        // Assert
+        let expected = indoc! {
+            "export interface Position {
+                x: number;
+                y: number;
+            }"
+        };
+        assert_eq!(JsPosition::DECL, expected);
+    }
+}

--- a/crates/auto-palette-wasm/src/swatch.rs
+++ b/crates/auto-palette-wasm/src/swatch.rs
@@ -1,0 +1,103 @@
+use wasm_bindgen::{prelude::wasm_bindgen, JsError};
+
+use crate::{color::JsColor, position::JsPosition};
+
+/// The swatch representation.
+#[derive(Debug)]
+#[wasm_bindgen(js_name = Swatch)]
+pub struct JsSwatch {
+    color: JsColor,
+    position: JsPosition,
+    population: usize,
+    ratio: f64,
+}
+
+#[wasm_bindgen(js_class = Swatch)]
+impl JsSwatch {
+    /// Creates a new `Swatch` instance.
+    ///
+    /// @param color The color of the swatch.
+    /// @param position The position of the swatch.
+    /// @param population The population of the swatch.
+    /// @param ratio The ratio of the swatch to the total population.
+    /// @returns A new `Swatch` instance.
+    /// @throws { JsError } if population is zero or ratio is not between 0 and 1.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        color: JsColor,
+        position: JsPosition,
+        population: usize,
+        ratio: f64,
+    ) -> Result<JsSwatch, JsError> {
+        if population == 0 {
+            return Err(JsError::new("Population cannot be zero"));
+        }
+        if !(0.0..=1.0).contains(&ratio) {
+            return Err(JsError::new("Ratio must be between 0 and 1"));
+        }
+
+        Ok(JsSwatch {
+            color,
+            position,
+            population,
+            ratio,
+        })
+    }
+
+    /// Returns the color of this swatch.
+    ///
+    /// @returns The color of this swatch.
+    #[wasm_bindgen(getter)]
+    pub fn color(&self) -> JsColor {
+        self.color.clone()
+    }
+
+    /// Returns the position of this swatch.
+    ///
+    /// @returns The position of this swatch.
+    #[wasm_bindgen(getter)]
+    pub fn position(&self) -> JsPosition {
+        self.position.clone()
+    }
+
+    /// Returns the population of this swatch.
+    ///
+    /// @returns The population of this swatch.
+    #[wasm_bindgen(getter)]
+    pub fn population(&self) -> usize {
+        self.population
+    }
+
+    /// Returns the ratio of this swatch.
+    ///
+    /// @returns The ratio of this swatch.
+    #[wasm_bindgen(getter)]
+    pub fn ratio(&self) -> f64 {
+        self.ratio
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn test_new_swatch() {
+        // Act
+        let color = JsColor::from_hex_string("#ff8000").unwrap();
+        let position = JsPosition { x: 10, y: 20 };
+        let population = 256;
+        let ratio = 0.25;
+        let actual = JsSwatch::new(color.clone(), position.clone(), population, ratio).unwrap();
+
+        // Assert
+        assert_eq!(actual.color(), color);
+        assert_eq!(actual.position(), position);
+        assert_eq!(actual.population(), population);
+        assert_eq!(actual.ratio(), ratio);
+    }
+}

--- a/packages/auto-palette-wasm/src/index.ts
+++ b/packages/auto-palette-wasm/src/index.ts
@@ -1,6 +1,6 @@
 import init from '@auto-palette/core';
 
-export { Color } from '@auto-palette/core';
+export { Color, Swatch } from '@auto-palette/core';
 
 /**
  * The input type for the WASM module.

--- a/packages/auto-palette-wasm/test/swatch.test.ts
+++ b/packages/auto-palette-wasm/test/swatch.test.ts
@@ -1,0 +1,50 @@
+import { Color, Swatch } from '@auto-palette/wasm';
+import { describe, expect } from 'vitest';
+
+describe('@auto-palette/wasm/swatch', () => {
+  describe('constructor', () => {
+    it('should create a Swatch from a color, position, population, and ratio', () => {
+      // Arrange
+      const color = Color.fromHexString('#ff0080');
+      const position = { x: 128, y: 256 };
+      const population = 100;
+      const ratio = 0.25;
+
+      // Act
+      const actual = new Swatch(color, position, population, ratio);
+
+      // Assert
+      expect(actual).toBeInstanceOf(Swatch);
+      expect(actual.color.toHexString()).toEqual('#FF0080');
+      expect(actual.position).toEqual(position);
+      expect(actual.population).toEqual(population);
+      expect(actual.ratio).toBeCloseTo(ratio);
+    });
+
+    it('should throw an error if population is zero', () => {
+      // Arrange
+      const color = Color.fromHexString('#ff0080');
+      const position = { x: 128, y: 256 };
+      const population = 0;
+      const ratio = 0.25;
+
+      // Act & Assert
+      expect(() => {
+        new Swatch(color, position, population, ratio);
+      }).toThrowError(new Error('Population cannot be zero'));
+    });
+
+    it('should throw an error if ratio is not between 0 and 1', () => {
+      // Arrange
+      const color = Color.fromHexString('#ff0080');
+      const position = { x: 128, y: 256 };
+      const population = 100;
+      const ratio = 1.5;
+
+      // Act & Assert
+      expect(() => {
+        new Swatch(color, position, population, ratio);
+      }).toThrowError(new Error('Ratio must be between 0 and 1'));
+    });
+  });
+});


### PR DESCRIPTION
## Description

This pull request implements support for the `Swatch` in the `auto-palette-wasm` package.  
The `Swatch` class provides detailed information about color, position, population, and ratio.

## Related Issue
N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
