### PR TITLE
Add Wasm support for Palette and Swatch to enable color extraction and selection in WebAssembly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ thiserror         = "2.0.12"
 tsify             = "0.4.5"
 wasm-bindgen-test = "0.3.50"
 wasm-bindgen      = "0.2.100"
+web-sys           = "0.3.77"
 
 [profile.dev]
 opt-level = 3

--- a/crates/auto-palette-wasm/Cargo.toml
+++ b/crates/auto-palette-wasm/Cargo.toml
@@ -24,9 +24,9 @@ auto-palette = { workspace = true, features = ["wasm"] }
 serde        = { workspace = true, features = ["derive"] }
 tsify        = { workspace = true }
 wasm-bindgen = { workspace = true }
+web-sys      = { workspace = true, features = ["ImageData"] }
 
 [dev-dependencies]
-image             = { workspace = true, features = ["jpeg", "png"] }
 indoc             = { workspace = true }
 serde_test        = { workspace = true }
 wasm-bindgen-test = { workspace = true }

--- a/crates/auto-palette-wasm/src/lib.rs
+++ b/crates/auto-palette-wasm/src/lib.rs
@@ -1,3 +1,5 @@
 mod color;
+mod palette;
 mod position;
 mod swatch;
+mod types;

--- a/crates/auto-palette-wasm/src/palette.rs
+++ b/crates/auto-palette-wasm/src/palette.rs
@@ -1,0 +1,106 @@
+use auto_palette::{Algorithm, ImageData, Palette, Swatch, Theme};
+use wasm_bindgen::{prelude::wasm_bindgen, JsError};
+use web_sys::ImageData as ImageSource;
+
+use crate::{
+    swatch::JsSwatch,
+    types::{JsAlgorithm, JsTheme},
+};
+
+/// The `Palette` class represents a color palette extracted from an image.
+#[derive(Debug)]
+#[wasm_bindgen(js_name = Palette)]
+pub struct JsPalette(Palette<f64>);
+
+#[wasm_bindgen(js_class = Palette)]
+impl JsPalette {
+    /// Creates a new `Palette` instance with the given swatches.
+    ///
+    /// @param swatches The swatches in the palette.
+    /// @returns A new `Palette` instance.
+    #[wasm_bindgen(constructor)]
+    pub fn new(swatches: Vec<JsSwatch>) -> Self {
+        let swatches = swatches
+            .into_iter()
+            .map(|swatch| {
+                let color = swatch.color();
+                let position = swatch.position();
+                Swatch::new(
+                    color.0,
+                    (position.x, position.y),
+                    swatch.population(),
+                    swatch.ratio(),
+                )
+            })
+            .collect();
+        let palette = Palette::new(swatches);
+        Self(palette)
+    }
+
+    /// Returns the number of swatches in this palette.
+    ///
+    /// @returns The number of swatches in this palette.
+    #[wasm_bindgen(getter)]
+    pub fn length(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns whether this palette is empty.
+    ///
+    /// @returns `true` if this palette is empty, `false` otherwise.
+    #[wasm_bindgen(js_name = isEmpty)]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Finds the best `n` swatches in this palette.
+    ///
+    /// @param n The number of swatches to find.
+    /// @param theme The theme to use when finding the swatches.
+    /// @returns The best swatches in this palette.
+    #[wasm_bindgen(js_name = findSwatches)]
+    pub fn find_swatches(
+        &self,
+        n: usize,
+        theme: Option<JsTheme>,
+    ) -> Result<Vec<JsSwatch>, JsError> {
+        let found = match theme {
+            Some(name) => {
+                let theme = Theme::try_from(name)?;
+                self.0.find_swatches_with_theme(n, theme).map_err(|e| {
+                    JsError::new(&format!("Failed to find swatches with theme: {}", e))
+                })?
+            }
+            None => self
+                .0
+                .find_swatches(n)
+                .map_err(|e| JsError::new(&format!("Failed to find swatches: {}", e)))?,
+        };
+
+        let swatches = found.into_iter().map(JsSwatch::from).collect::<Vec<_>>();
+        Ok(swatches)
+    }
+
+    /// Extracts a color palette from the given image.
+    ///
+    /// @param image The image to extract the palette from.
+    /// @param algorithm The algorithm to use for palette extraction. Defaults to 'dbscan'.
+    /// @returns A new `Palette` instance.
+    /// @throws Error if the image is invalid or the palette extraction fails.
+    #[wasm_bindgen]
+    pub fn extract(image: &ImageSource, algorithm: Option<JsAlgorithm>) -> Result<Self, JsError> {
+        let width = image.width();
+        let height = image.height();
+        let data = image.data();
+        let image_data = ImageData::new(width, height, &data)
+            .map_err(|e| JsError::new(&format!("Failed to create ImageData from image: {}", e)))?;
+
+        let algorithm = algorithm
+            .map(Algorithm::try_from)
+            .unwrap_or(Ok(Algorithm::DBSCAN))?;
+
+        let palette = Palette::extract_with_algorithm(&image_data, algorithm)
+            .map_err(|e| JsError::new(&format!("Failed to extract palette from image: {}", e)))?;
+        Ok(Self(palette))
+    }
+}

--- a/crates/auto-palette-wasm/src/swatch.rs
+++ b/crates/auto-palette-wasm/src/swatch.rs
@@ -1,3 +1,4 @@
+use auto_palette::Swatch;
 use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
 use crate::{color::JsColor, position::JsPosition};
@@ -77,8 +78,30 @@ impl JsSwatch {
     }
 }
 
+impl From<Swatch<f64>> for JsSwatch {
+    fn from(swatch: Swatch<f64>) -> Self {
+        let color = JsColor(*swatch.color());
+        let position = JsPosition {
+            x: swatch.position().0,
+            y: swatch.position().1,
+        };
+        let population = swatch.population();
+        let ratio = swatch.ratio();
+
+        JsSwatch {
+            color,
+            position,
+            population,
+            ratio,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use auto_palette::color::Color;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     use super::*;
@@ -96,6 +119,23 @@ mod tests {
 
         // Assert
         assert_eq!(actual.color(), color);
+        assert_eq!(actual.position(), position);
+        assert_eq!(actual.population(), population);
+        assert_eq!(actual.ratio(), ratio);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_swatch() {
+        // Act
+        let color = Color::from_str("#ff8000").unwrap();
+        let position = JsPosition { x: 10, y: 20 };
+        let population = 256;
+        let ratio = 0.25;
+        let swatch = Swatch::new(color.clone(), (position.x, position.y), population, ratio);
+        let actual = JsSwatch::from(swatch);
+
+        // Assert
+        assert_eq!(actual.color(), JsColor::from_hex_string("#ff8000").unwrap());
         assert_eq!(actual.position(), position);
         assert_eq!(actual.population(), population);
         assert_eq!(actual.ratio(), ratio);

--- a/crates/auto-palette-wasm/src/types.rs
+++ b/crates/auto-palette-wasm/src/types.rs
@@ -1,0 +1,112 @@
+use std::str::FromStr;
+
+use auto_palette::{Algorithm, Theme};
+use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
+use web_sys::js_sys::JsString;
+
+#[wasm_bindgen(typescript_custom_section)]
+// language=TypeScript
+const TYPE_DEFINITION: &'static str = r#"
+/**
+ * The algorithm of the palette.
+ */
+export type Algorithm = "dbscan" | "dbscan++" | "kmeans";
+
+/**
+ * The theme of the palette.
+ */
+export type Theme = "vivid" | "muted" | "light" | "dark" | "colorful";
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    /// The algorithm of the palette extraction.
+    #[wasm_bindgen(typescript_type = "Algorithm")]
+    pub type JsAlgorithm;
+
+    /// The theme of the swatch selection.
+    #[wasm_bindgen(typescript_type = "Theme")]
+    pub type JsTheme;
+}
+
+impl TryFrom<JsAlgorithm> for Algorithm {
+    type Error = JsError;
+
+    fn try_from(name: JsAlgorithm) -> Result<Self, Self::Error> {
+        let value: JsValue = name.into();
+        let string: JsString = value.into();
+        Algorithm::from_str(
+            &string
+                .as_string()
+                .ok_or_else(|| JsError::new("Failed to retrieve algorithm name"))?,
+        )
+        .map_err(|_| JsError::new(&format!("Unknown algorithm name: {}", string)))
+    }
+}
+
+impl TryFrom<JsTheme> for Theme {
+    type Error = JsError;
+
+    fn try_from(name: JsTheme) -> Result<Self, Self::Error> {
+        let value: JsValue = name.into();
+        let string: JsString = value.into();
+        string
+            .as_string()
+            .ok_or_else(|| JsError::new("Failed to retrieve theme name"))
+            .and_then(|name| {
+                Theme::from_str(&name)
+                    .map_err(|_| JsError::new(&format!("Unknown theme name: {}", name)))
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn test_algorithm_try_from() {
+        // Act
+        let algorithm: JsAlgorithm = JsValue::from_str("dbscan").into();
+        let result: Result<Algorithm, JsError> = Algorithm::try_from(algorithm);
+
+        // Assert
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Algorithm::DBSCAN);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_algorithm_try_from_error() {
+        // Act
+        let algorithm: JsAlgorithm = JsValue::from_str("unknown").into();
+        let result: Result<Algorithm, JsError> = Algorithm::try_from(algorithm);
+
+        // Assert
+        assert!(result.is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_theme_try_from() {
+        // Act
+        let theme: JsTheme = JsValue::from_str("vivid").into();
+        let result: Result<Theme, JsError> = Theme::try_from(theme);
+
+        // Assert
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Theme::Vivid);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_theme_try_from_error() {
+        // Act
+        let theme: JsTheme = JsValue::from_str("unknown").into();
+        let result: Result<Theme, JsError> = Theme::try_from(theme);
+
+        // Assert
+        assert!(result.is_err());
+    }
+}

--- a/packages/auto-palette-wasm/package.json
+++ b/packages/auto-palette-wasm/package.json
@@ -42,6 +42,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "@napi-rs/canvas": "^0.1.69",
     "esbuild-plugin-copy": "^2.1.1",
     "tsup": "^8.4.0",
     "wasm-pack": "^0.13.1"

--- a/packages/auto-palette-wasm/src/index.ts
+++ b/packages/auto-palette-wasm/src/index.ts
@@ -1,6 +1,12 @@
 import init from '@auto-palette/core';
 
-export { Color, Swatch } from '@auto-palette/core';
+export {
+  type Algorithm,
+  Color,
+  Palette,
+  Swatch,
+  type Theme,
+} from '@auto-palette/core';
 
 /**
  * The input type for the WASM module.

--- a/packages/auto-palette-wasm/test/image.ts
+++ b/packages/auto-palette-wasm/test/image.ts
@@ -1,0 +1,15 @@
+import { createCanvas, loadImage } from '@napi-rs/canvas';
+
+/**
+ * Load an image from the specified source.
+ *
+ * @param source - The source of the image.
+ * @returns The loaded image.
+ */
+export async function loadImageData(source: string): Promise<ImageData> {
+  const image = await loadImage(source);
+  const canvas = createCanvas(image.width, image.height);
+  const context = canvas.getContext('2d');
+  context.drawImage(image, 0, 0);
+  return context.getImageData(0, 0, image.width, image.height) as ImageData;
+}

--- a/packages/auto-palette-wasm/test/palette.test.ts
+++ b/packages/auto-palette-wasm/test/palette.test.ts
@@ -1,0 +1,243 @@
+import {
+  type Algorithm,
+  Color,
+  Palette,
+  Swatch,
+  type Theme,
+} from '@auto-palette/core';
+import { describe, expect } from 'vitest';
+import { loadImageData } from './image';
+
+describe('@auto-palette/wasm/palette', () => {
+  describe('constructor', () => {
+    it('should create a Palette instance', () => {
+      // Act
+      const actual = new Palette([
+        new Swatch(
+          Color.fromHexString('#6DE1D2'),
+          { x: 120, y: 240 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#FFD63A'),
+          { x: 200, y: 300 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#FFA955'),
+          { x: 150, y: 100 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#FF6F61'),
+          { x: 300, y: 400 },
+          100,
+          0.25,
+        ),
+      ]);
+
+      // Assert
+      expect(actual).toBeDefined();
+      expect(actual.isEmpty()).toBeFalsy();
+      expect(actual).toHaveLength(4);
+    });
+
+    it('should create an empty Palette instance', () => {
+      // Act
+      const actual = new Palette([]);
+
+      // Assert
+      expect(actual).toBeDefined();
+      expect(actual.isEmpty()).toBeTruthy();
+      expect(actual).toHaveLength(0);
+    });
+  });
+
+  describe('findSwatches', () => {
+    let palette: Palette;
+    beforeAll(() => {
+      palette = new Palette([
+        new Swatch(
+          Color.fromHexString('#FF6F61'),
+          { x: 120, y: 240 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#6DE1D2'),
+          { x: 200, y: 300 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#FFD63A'),
+          { x: 150, y: 100 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#3F4F44'),
+          { x: 300, y: 400 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#A27B5C'),
+          { x: 400, y: 500 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#604652'),
+          { x: 500, y: 600 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#F7CFD8'),
+          { x: 120, y: 240 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#F4F8D3'),
+          { x: 200, y: 300 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#A6D6D6'),
+          { x: 150, y: 100 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#210F37'),
+          { x: 300, y: 400 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#2A0A1D'),
+          { x: 400, y: 500 },
+          100,
+          0.25,
+        ),
+        new Swatch(
+          Color.fromHexString('#4F1C51'),
+          { x: 500, y: 600 },
+          100,
+          0.25,
+        ),
+      ]);
+    });
+
+    it('should find the swatches from the palette', () => {
+      // Act
+      const actual = palette.findSwatches(3);
+
+      // Assert
+      expect(actual).toHaveLength(3);
+      expect(actual[0].color.toHexString()).toEqual('#FF6F61');
+      expect(actual[1].color.toHexString()).toEqual('#FFD63A');
+      expect(actual[2].color.toHexString()).toEqual('#6DE1D2');
+    });
+
+    it.each([
+      { theme: 'vivid', count: 3, expected: ['#4F1C51', '#FFD63A', '#FF6F61'] },
+      { theme: 'muted', count: 3, expected: ['#A27B5C', '#3F4F44', '#604652'] },
+      { theme: 'light', count: 3, expected: ['#6DE1D2', '#F7CFD8', '#FF6F61'] },
+      { theme: 'dark', count: 3, expected: ['#604652', '#210F37', '#3F4F44'] },
+      {
+        theme: 'colorful',
+        count: 3,
+        expected: ['#FF6F61', '#6DE1D2', '#4F1C51'],
+      },
+    ])(
+      'should find the swatches from the palette with $theme theme',
+      ({ theme, count, expected }) => {
+        // Act
+        const actual = palette.findSwatches(count, theme as Theme);
+
+        // Assert
+        expect(actual).toHaveLength(3);
+        expect(actual[0].color.toHexString()).toEqual(expected[0]);
+        expect(actual[1].color.toHexString()).toEqual(expected[1]);
+        expect(actual[2].color.toHexString()).toEqual(expected[2]);
+      },
+    );
+
+    it('should return an empty array if the count is less than 1', () => {
+      // Act
+      const actual = palette.findSwatches(0);
+
+      // Assert
+      expect(actual).toHaveLength(0);
+    });
+
+    it('should throw an error if the theme is not supported', () => {
+      // Assert
+      expect(() => {
+        // Act
+        const theme = 'unsupported' as Theme;
+        palette.findSwatches(3, theme);
+      }).toThrowError('Unknown theme name: unsupported');
+    });
+  });
+
+  describe('extract', () => {
+    let imageData: ImageData;
+    beforeAll(async () => {
+      imageData = await loadImageData('../../gfx/flags/za.png');
+    });
+
+    it('should extract a palette from an image', () => {
+      // Act
+      const actual = Palette.extract(imageData);
+
+      // Assert
+      expect(actual.isEmpty()).toBeFalsy();
+      expect(actual.length).toBeGreaterThanOrEqual(6);
+
+      const swatches = actual.findSwatches(5, 'vivid');
+      expect(swatches.length).toBe(5);
+      swatches.forEach((swatch) => {
+        console.info('Swatch color: %s', swatch.color.toHexString());
+      });
+    });
+
+    it('should extract a palette from an image with the given algorithm', () => {
+      // Act
+      const actual = Palette.extract(imageData, 'dbscan++');
+
+      // Assert
+      expect(actual.isEmpty()).toBeFalsy();
+      expect(actual.length).toBeGreaterThanOrEqual(6);
+
+      const swatches = actual.findSwatches(5, 'vivid');
+      expect(swatches.length).toBe(5);
+      swatches.forEach((swatch) => {
+        console.info('Swatch color: %s', swatch.color.toHexString());
+      });
+    });
+
+    it('should throw an error if the image data is empty', () => {
+      // Act & Assert
+      expect(() => {
+        const imageData = new ImageData(0, 0);
+        Palette.extract(imageData);
+      }).toThrowError('ImageData is not defined');
+    });
+
+    it('should throw an error if the algorithm is not supported', () => {
+      // Act & Assert
+      expect(() => {
+        const algorithm = 'unsupported' as Algorithm;
+        Palette.extract(imageData, algorithm);
+      }).toThrowError('Unknown algorithm name: unsupported');
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
 
   packages/auto-palette-wasm:
     devDependencies:
+      '@napi-rs/canvas':
+        specifier: ^0.1.69
+        version: 0.1.69
       esbuild-plugin-copy:
         specifier: ^2.1.1
         version: 2.1.1(esbuild@0.25.2)
@@ -278,6 +281,70 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@napi-rs/canvas-android-arm64@0.1.69':
+    resolution: {integrity: sha512-4icWTByY8zPvM9SelfQKf3I6kwXw0aI5drBOVrwfER5kjwXJd78FPSDSZkxDHjvIo9Q86ljl18Yr963ehA4sHQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.69':
+    resolution: {integrity: sha512-HOanhhYlHdukA+unjelT4Dg3ta7e820x87/AG2dKUMsUzH19jaeZs9bcYjzEy2vYi/dFWKz7cSv2yaIOudB8Yg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.69':
+    resolution: {integrity: sha512-SIp7WfhxAPnSVK9bkFfJp+84rbATCIq9jMUzDwpCLhQ+v+OqtXe4pggX1oeV+62/HK6BT1t18qRmJfyqwJ9f3g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.69':
+    resolution: {integrity: sha512-Ls+KujCp6TGpkuMVFvrlx+CxtL+casdkrprFjqIuOAnB30Mct6bCEr+I83Tu29s3nNq4EzIGjdmA3fFAZG/Dtw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.69':
+    resolution: {integrity: sha512-m8VcGmeSBNRbHZBd1srvdM1aq/ScS2y8KqGqmCCEgJlytYK4jdULzAo2K/BPKE1v3xvn8oUPZDLI/NBJbJkEoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.69':
+    resolution: {integrity: sha512-a3xjNRIeK2m2ZORGv2moBvv3vbkaFZG1QKMeiEv/BKij+rkztuEhTJGMar+buICFgS0fLgphXXsKNkUSJb7eRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.69':
+    resolution: {integrity: sha512-pClUoJF5wdC9AvD0mc15G9JffL1Q85nuH1rLSQPRkGmGmQOtRjw5E9xNbanz7oFUiPbjH7xcAXUjVAcf7tdgPQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.69':
+    resolution: {integrity: sha512-96X3bFAmzemfw84Ts6Jg/omL86uuynvK06MWGR/mp3JYNumY9RXofA14eF/kJIYelbYFWXcwpbcBR71lJ6G/YQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.69':
+    resolution: {integrity: sha512-2QTsEFO72Kwkj53W9hc5y1FAUvdGx0V+pjJB+9oQF6Ys9+y989GyPIl5wZDzeh8nIJW6koZZ1eFa8pD+pA5BFQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.69':
+    resolution: {integrity: sha512-Q4YA8kVnKarApBVLu7F8icGlIfSll5Glswo5hY6gPS4Is2dCI8+ig9OeDM8RlwYevUIxKq8lZBypN8Q1iLAQ7w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.69':
+    resolution: {integrity: sha512-ydvNeJMRm+l3T14yCoUKqjYQiEdXDq1isznI93LEBGYssXKfSaLNLHOkeM4z9Fnw9Pkt2EKOCAtW9cS4b00Zcg==}
+    engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1522,6 +1589,49 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@napi-rs/canvas-android-arm64@0.1.69':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.69':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.69':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.69':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.69':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.69':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.69':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.69':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.69':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.69':
+    optional: true
+
+  '@napi-rs/canvas@0.1.69':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.69
+      '@napi-rs/canvas-darwin-arm64': 0.1.69
+      '@napi-rs/canvas-darwin-x64': 0.1.69
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.69
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.69
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.69
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.69
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.69
+      '@napi-rs/canvas-linux-x64-musl': 0.1.69
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.69
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Description

This pull request adds WebAssembly (Wasm) support for the `Palette` and `Swatch` classes in the `auto-palette-wasm` package.  
These changes enable efficient color palette extraction and swatch selection using WebAssembly.

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
