### PR TITLE
Fix type definitions for color structs and add unit tests to validate generated TS types

### DIFF
--- a/crates/auto-palette/src/color/ansi16.rs
+++ b/crates/auto-palette/src/color/ansi16.rs
@@ -261,6 +261,8 @@ fn from_rgb(r: u8, g: u8, b: u8) -> u8 {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
+    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -339,6 +341,18 @@ mod tests {
                 Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_tsify() {
+        // Act & Assert
+        let expected = indoc! {
+            "export interface Ansi16 {
+                code: number;
+            }"
+        };
+        assert_eq!(Ansi16::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/ansi256.rs
+++ b/crates/auto-palette/src/color/ansi256.rs
@@ -105,6 +105,8 @@ fn from_rgb(r: u8, g: u8, b: u8) -> u8 {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
+    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -164,6 +166,18 @@ mod tests {
                 Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_tsify() {
+        // Act & Assert
+        let expected = indoc! {
+            "export interface Ansi256 {
+                code: number;
+            }"
+        };
+        assert_eq!(Ansi256::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/cmyk.rs
+++ b/crates/auto-palette/src/color/cmyk.rs
@@ -33,7 +33,7 @@ use crate::{color::RGB, FloatNumber};
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct CMYK<T>
+pub struct CMYK<T = f64>
 where
     T: FloatNumber,
 {
@@ -110,6 +110,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
     use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
@@ -213,7 +214,7 @@ mod tests {
     fn test_tsify() {
         // Assert
         let expected = indoc! {
-            // language=ts
+            // language=typescript
             "export interface CMYK<T> {
                 c: number;
                 m: number;

--- a/crates/auto-palette/src/color/hsl.rs
+++ b/crates/auto-palette/src/color/hsl.rs
@@ -35,10 +35,11 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct HSL<T>
+pub struct HSL<T = f64>
 where
     T: FloatNumber,
 {
+    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub h: Hue<T>,
     #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub s: T,
@@ -115,6 +116,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
     use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
@@ -210,9 +212,9 @@ mod tests {
     fn test_tsify() {
         // Assert
         let expected = indoc! {
-            // language=ts
+            // language=typescript
             "export interface HSL<T> {
-                h: Hue<T>;
+                h: number;
                 s: number;
                 l: number;
             }"

--- a/crates/auto-palette/src/color/hsv.rs
+++ b/crates/auto-palette/src/color/hsv.rs
@@ -35,10 +35,11 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct HSV<T>
+pub struct HSV<T = f64>
 where
     T: FloatNumber,
 {
+    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub h: Hue<T>,
     #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub s: T,
@@ -118,6 +119,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
     use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
@@ -212,9 +214,9 @@ mod tests {
     fn test_tsify() {
         // Assert
         let expected = indoc! {
-            // language=ts
+            // language=typescript
             "export interface HSV<T> {
-                h: Hue<T>;
+                h: number;
                 s: number;
                 v: number;
             }"

--- a/crates/auto-palette/src/color/hue.rs
+++ b/crates/auto-palette/src/color/hue.rs
@@ -26,7 +26,7 @@ use crate::math::FloatNumber;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct Hue<T>(#[cfg_attr(feature = "wasm", tsify(type = "number"))] T)
+pub struct Hue<T = f64>(#[cfg_attr(feature = "wasm", tsify(type = "number"))] T)
 where
     T: FloatNumber;
 
@@ -139,6 +139,7 @@ where
 mod tests {
     use std::f64::consts::PI;
 
+    #[cfg(feature = "wasm")]
     use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
@@ -217,7 +218,7 @@ mod tests {
     fn test_tsify() {
         // Assert
         let expected = indoc! {
-            // language=ts
+            // language=typescript
             "export type Hue<T> = number;"
         };
         assert_eq!(Hue::<f64>::DECL, expected);

--- a/crates/auto-palette/src/color/lab.rs
+++ b/crates/auto-palette/src/color/lab.rs
@@ -39,7 +39,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct Lab<T, W = D65>
+pub struct Lab<T = f64, W = D65>
 where
     T: FloatNumber,
     W: WhitePoint,
@@ -242,6 +242,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
+    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -308,6 +310,21 @@ mod tests {
                 Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_tsify() {
+        // Act & Assert
+        let expected = indoc! {
+            // language=typescript
+            "export interface Lab<T> {
+                l: number;
+                a: number;
+                b: number;
+            }"
+        };
+        assert_eq!(Lab::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/lchab.rs
+++ b/crates/auto-palette/src/color/lchab.rs
@@ -38,7 +38,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct LCHab<T, W = D65>
+pub struct LCHab<T = f64, W = D65>
 where
     T: FloatNumber,
     W: WhitePoint,
@@ -47,6 +47,7 @@ where
     pub l: T,
     #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub c: T,
+    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub h: Hue<T>,
     #[cfg_attr(feature = "wasm", serde(skip))]
     _marker: PhantomData<W>,
@@ -110,6 +111,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
+    use indoc::indoc;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
 
@@ -181,6 +184,21 @@ mod tests {
                 Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_tsify() {
+        // Act & Assert
+        let expected = indoc! {
+            // language=typescript
+            "export interface LCHab<T> {
+                l: number;
+                c: number;
+                h: number;
+            }"
+        };
+        assert_eq!(LCHab::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/lchuv.rs
+++ b/crates/auto-palette/src/color/lchuv.rs
@@ -38,7 +38,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct LCHuv<T, W = D65>
+pub struct LCHuv<T = f64, W = D65>
 where
     T: FloatNumber,
     W: WhitePoint,
@@ -47,6 +47,7 @@ where
     pub l: T,
     #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub c: T,
+    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub h: Hue<T>,
     #[cfg_attr(feature = "wasm", serde(skip))]
     _marker: PhantomData<W>,
@@ -110,6 +111,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
+    use indoc::indoc;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
 
@@ -181,6 +184,21 @@ mod tests {
                 Token::StructEnd,
             ],
         )
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_tsify() {
+        // Act & Assert
+        let expected = indoc! {
+            // language=typescript
+            "export interface LCHuv<T> {
+                l: number;
+                c: number;
+                h: number;
+            }"
+        };
+        assert_eq!(LCHuv::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/luv.rs
+++ b/crates/auto-palette/src/color/luv.rs
@@ -38,7 +38,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct Luv<T, W = D65>
+pub struct Luv<T = f64, W = D65>
 where
     T: FloatNumber,
     W: WhitePoint,
@@ -154,6 +154,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
+    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -242,6 +244,21 @@ mod tests {
                 Token::StructEnd,
             ],
         )
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_tsify() {
+        // Act & Assert
+        let expected = indoc! {
+            // language=typescript
+            "export interface Luv<T> {
+                l: number;
+                u: number;
+                v: number;
+            }"
+        };
+        assert_eq!(Luv::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/oklab.rs
+++ b/crates/auto-palette/src/color/oklab.rs
@@ -35,7 +35,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct Oklab<T>
+pub struct Oklab<T = f64>
 where
     T: FloatNumber,
 {
@@ -124,6 +124,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
+    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_tokens, Token};
@@ -195,6 +197,21 @@ mod tests {
                 Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_tsify() {
+        // Act & Assert
+        let expected = indoc! {
+            // language=typescript
+            "export interface Oklab<T> {
+                l: number;
+                a: number;
+                b: number;
+            }"
+        };
+        assert_eq!(Oklab::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/oklch.rs
+++ b/crates/auto-palette/src/color/oklch.rs
@@ -37,7 +37,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct Oklch<T>
+pub struct Oklch<T = f64>
 where
     T: FloatNumber,
 {
@@ -45,6 +45,7 @@ where
     pub l: T,
     #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub c: T,
+    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub h: Hue<T>,
 }
 
@@ -102,6 +103,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
+    use indoc::indoc;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
 
@@ -172,6 +175,21 @@ mod tests {
                 Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_tsify() {
+        // Act & Assert
+        let expected = indoc! {
+            // language=ts
+            "export interface Oklch<T> {
+                l: number;
+                c: number;
+                h: number;
+            }"
+        };
+        assert_eq!(Oklch::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/rgb.rs
+++ b/crates/auto-palette/src/color/rgb.rs
@@ -223,6 +223,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
     use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
@@ -294,7 +295,7 @@ mod tests {
     #[test]
     #[cfg(feature = "wasm")]
     fn test_tsify() {
-        // Assert
+        // Act & Assert
         let expected = indoc! {
             // language=ts
             "export interface RGB {

--- a/crates/auto-palette/src/color/xyz.rs
+++ b/crates/auto-palette/src/color/xyz.rs
@@ -41,12 +41,15 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct XYZ<T>
+pub struct XYZ<T = f64>
 where
     T: FloatNumber,
 {
+    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub x: T,
+    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub y: T,
+    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub z: T,
 }
 
@@ -323,6 +326,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "wasm")]
+    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -389,6 +394,21 @@ mod tests {
                 Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    #[cfg(feature = "wasm")]
+    fn test_tsify() {
+        // Act & Assert
+        let expected = indoc! {
+            // language=ts
+            "export interface XYZ<T> {
+                x: number;
+                y: number;
+                z: number;
+            }"
+        };
+        assert_eq!(XYZ::<f64>::DECL, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Description

This pull request fixes type definitions for color-related structs and adds unit tests to validate the generated TypeScript types.  
These changes ensure that the TypeScript definitions are accurate and align with the expected behavior of the Rust code.

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
