### PR TITLE
Add browser-based E2E tests and node-based E2E tests for @auto-palette/wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,6 @@ jobs:
         working-directory: ./packages/auto-palette-wasm
         run: pnpm build
 
-      - name: Test the wasm package
+      - name: Run the unit tests and e2e tests
         working-directory: ./packages/auto-palette-wasm
-        run: pnpm test
+        run: pnpm test:e2e:install && pnpm test

--- a/packages/auto-palette-wasm/package.json
+++ b/packages/auto-palette-wasm/package.json
@@ -40,15 +40,21 @@
     "build:ts": "tsup",
     "build:wasm": "wasm-pack build --release --target web --out-name auto_palette --out-dir ./dist ../../crates/auto-palette-wasm",
     "test": "vitest run --coverage",
+    "test:unit": "vitest run --project unit",
+    "test:e2e": "vitest run --project e2e*",
+    "test:e2e:install": "pnpm exec playwright install chromium --with-deps",
     "test:ui": "vitest run --coverage --ui",
     "test:bench": "vitest bench --run"
   },
   "devDependencies": {
     "@napi-rs/canvas": "^0.1.69",
+    "@vitest/browser": "^3.1.1",
     "@vitest/coverage-v8": "^3.1.1",
     "@vitest/ui": "^3.1.1",
     "auto-palette": "^1.4.0",
     "esbuild-plugin-copy": "^2.1.1",
+    "jest-matcher-utils": "^29.7.0",
+    "playwright": "^1.51.1",
     "tsup": "^8.4.0",
     "wasm-pack": "^0.13.1"
   }

--- a/packages/auto-palette-wasm/src/index.ts
+++ b/packages/auto-palette-wasm/src/index.ts
@@ -11,7 +11,7 @@ export {
 /**
  * The input type for the WASM module.
  */
-export type Module =
+export type ModuleInput =
   | RequestInfo
   | URL
   | Response
@@ -25,7 +25,7 @@ export type Module =
  * @returns The Promise that resolves when the WASM module is initialized.
  */
 export async function initialize(
-  module: Module | Promise<Module>,
+  module: ModuleInput | Promise<ModuleInput>,
 ): Promise<void> {
   await init({ module_or_path: module });
 }

--- a/packages/auto-palette-wasm/test/matchers/index.ts
+++ b/packages/auto-palette-wasm/test/matchers/index.ts
@@ -1,0 +1,39 @@
+import { expect } from 'vitest';
+import { toBeSameColor } from './toBeSameColor';
+import { toBeSimilarColor } from './toBeSimilarColor';
+
+/**
+ * Custom matchers for AutoPalette.
+ *
+ * These matchers are automatically extended to the global scope.
+ */
+interface AutoPaletteMatchers<R = unknown> {
+  /**
+   * Check whether the received color is the same as the expected color.
+   *
+   * @param expected - The expected color.
+   * @return The matcher result.
+   */
+  toBeSameColor(expected: unknown): R;
+
+  /**
+   * Check whether the received color is similar to the expected color.
+   *
+   * @param expected - The expected color.
+   * @param threshold - The allowed threshold.
+   * @return The matcher result.
+   */
+  toBeSimilarColor(expected: unknown, threshold?: number): R;
+}
+
+declare module 'vitest' {
+  // biome-ignore lint/suspicious/noExplicitAny: The generic type 'T' could be any type.
+  interface Assertion<T = any> extends AutoPaletteMatchers<T> {}
+
+  interface AsymmetricMatchersContaining extends AutoPaletteMatchers {}
+}
+
+expect.extend({
+  toBeSameColor,
+  toBeSimilarColor,
+});

--- a/packages/auto-palette-wasm/test/matchers/toBeSameColor.test.ts
+++ b/packages/auto-palette-wasm/test/matchers/toBeSameColor.test.ts
@@ -1,0 +1,77 @@
+import { Color } from '@auto-palette/core';
+import { describe, expect } from 'vitest';
+
+describe('@auto-palette/wasm/matchers', () => {
+  describe('.toBeSameColor', () => {
+    it('should pass when colors are the same', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = Color.fromHexString('#ff8000');
+
+      // Assert
+      expect(received).toBeSameColor(expected);
+    });
+
+    it('should pass when colors are the same (hex string format)', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = '#ff8000';
+
+      // Assert
+      expect(received).toBeSameColor(expected);
+    });
+
+    it('should pass when colors are the same (int format)', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = 0xff8000;
+
+      // Assert
+      expect(received).toBeSameColor(expected);
+    });
+
+    it('should fail when colors are different', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = Color.fromHexString('#00ff80');
+
+      // Assert
+      expect(() => {
+        expect(received).toBeSameColor(expected);
+      }).toThrowError(/Expected color to be the same as:/);
+    });
+
+    it('should fail when expected is not a color', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = 'not a color';
+
+      // Assert
+      expect(() => {
+        expect(received).toBeSameColor(expected);
+      }).toThrowError(/Expected value is not a valid color/);
+    });
+
+    describe('.not.toBeSameColor', () => {
+      it('should pass when colors are different', () => {
+        // Act
+        const received = Color.fromHexString('#ff8000');
+        const expected = Color.fromHexString('#00ff80');
+
+        // Assert
+        expect(received).not.toBeSameColor(expected);
+      });
+
+      it('should fail when colors are the same', () => {
+        // Act
+        const received = Color.fromHexString('#ff8000');
+        const expected = Color.fromHexString('#ff8000');
+
+        // Assert
+        expect(() => {
+          expect(received).not.toBeSameColor(expected);
+        }).toThrowError(/Expected color to not be the same as:/);
+      });
+    });
+  });
+});

--- a/packages/auto-palette-wasm/test/matchers/toBeSameColor.ts
+++ b/packages/auto-palette-wasm/test/matchers/toBeSameColor.ts
@@ -1,0 +1,50 @@
+import type { Color } from '@auto-palette/wasm';
+import {
+  EXPECTED_COLOR,
+  matcherErrorMessage,
+  matcherHint,
+  printExpected,
+  printReceived,
+  printWithType,
+} from 'jest-matcher-utils';
+import { parseColor } from '../utils/color';
+import type { MatcherState } from './types';
+
+/**
+ * Check if two colors are the same.
+ *
+ * @param received - The received color.
+ * @param expected - The expected color.
+ * @returns An object containing the result of the comparison.
+ */
+export function toBeSameColor(
+  this: MatcherState,
+  received: Color,
+  expected: unknown,
+) {
+  const matcherName = this.isNot ? '.not.toBeSameColor' : '.toBeSameColor';
+  const expectedColor = parseColor(expected);
+  if (!expectedColor) {
+    const message = matcherErrorMessage(
+      matcherName,
+      'Expected value is not a valid color',
+      `${EXPECTED_COLOR('expected')} is not a valid color`,
+      printWithType<unknown>('expected', expected, printExpected),
+    );
+    throw new Error(message);
+  }
+
+  const receivedHex = received.toHexString();
+  const expectedHex = expectedColor.toHexString();
+
+  return {
+    pass: receivedHex.toUpperCase() === expectedHex.toUpperCase(),
+    message: () => {
+      return `${matcherHint(matcherName, 'received', 'expected')}
+        Expected color to ${this.isNot ? 'not be' : 'be'} the same as:
+          Expected: ${printExpected(expectedHex)}
+          Received: ${printReceived(receivedHex)}
+      `;
+    },
+  };
+}

--- a/packages/auto-palette-wasm/test/matchers/toBeSimilarColor.test.ts
+++ b/packages/auto-palette-wasm/test/matchers/toBeSimilarColor.test.ts
@@ -1,0 +1,66 @@
+import { Color } from '@auto-palette/core';
+import { describe, it } from 'vitest';
+
+describe('@auto-palette/wasm/matchers', () => {
+  describe('.toBeSimilarColor', () => {
+    it('should pass when colors are similar', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = Color.fromHexString('#ff7f00');
+
+      // Assert
+      expect(received).toBeSimilarColor(expected);
+    });
+
+    it('should pass when colors are the same', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = Color.fromHexString('#ff8000');
+
+      // Assert
+      expect(received).toBeSimilarColor(expected);
+    });
+
+    it('should pass when colors are similar with a tolerance', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = Color.fromHexString('#ff8800');
+
+      // Assert
+      expect(received).toBeSimilarColor(expected, 5.0);
+    });
+
+    it('should fail when colors are different', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = Color.fromHexString('#00ff80');
+
+      // Assert
+      expect(() => {
+        expect(received).toBeSimilarColor(expected);
+      }).toThrowError(/Expected color to be similar to:/);
+    });
+  });
+
+  describe('.not.toBeSimilarColor', () => {
+    it('should pass when colors are different', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = Color.fromHexString('#00ff80');
+
+      // Assert
+      expect(received).not.toBeSimilarColor(expected);
+    });
+
+    it('should fail when colors are similar', () => {
+      // Act
+      const received = Color.fromHexString('#ff8000');
+      const expected = Color.fromHexString('#ff7f00');
+
+      // Assert
+      expect(() => {
+        expect(received).not.toBeSimilarColor(expected);
+      }).toThrowError(/Expected color to not be similar to:/);
+    });
+  });
+});

--- a/packages/auto-palette-wasm/test/matchers/toBeSimilarColor.ts
+++ b/packages/auto-palette-wasm/test/matchers/toBeSimilarColor.ts
@@ -1,0 +1,59 @@
+import type { Color } from '@auto-palette/wasm';
+import {
+  EXPECTED_COLOR,
+  matcherErrorMessage,
+  matcherHint,
+  printExpected,
+  printReceived,
+  printWithType,
+} from 'jest-matcher-utils';
+import { parseColor } from '../utils/color';
+import type { ExpectationResult, MatcherState } from './types';
+
+const DEFAULT_EPSILON = 1.0;
+
+/**
+ * Check if two colors are similar.
+ *
+ * @param received - The received color.
+ * @param expected - The expected color.
+ * @param epsilon - The tolerance for similarity (default is 0.1).
+ * @returns An object containing the result of the comparison.
+ */
+export function toBeSimilarColor(
+  this: MatcherState,
+  received: Color,
+  expected: unknown,
+  epsilon = DEFAULT_EPSILON,
+): ExpectationResult {
+  const matcherName = this.isNot
+    ? '.not.toBeSimilarColor'
+    : '.toBeSimilarColor';
+  const expectedColor = parseColor(expected);
+  if (!expectedColor) {
+    const message = matcherErrorMessage(
+      matcherHint(matcherName, 'received', 'expected'),
+      'Expected value is not a valid color',
+      `${EXPECTED_COLOR('expected')} is not a valid color`,
+      printWithType('expected', expected, printExpected),
+    );
+    throw new Error(message);
+  }
+
+  const { l: l1, a: a1, b: b1 } = received.toLab();
+  const { l: l2, a: a2, b: b2 } = expectedColor.toLab();
+  const deltaE = Math.sqrt((l1 - l2) ** 2 + (a1 - a2) ** 2 + (b1 - b2) ** 2);
+
+  return {
+    pass: deltaE < epsilon,
+    message: () => {
+      return `${matcherHint(matcherName, 'received', 'expected')}
+        Expected color to ${this.isNot ? 'not be' : 'be'} similar to:
+          Expected: ${printExpected(expectedColor.toHexString())}
+          Received: ${printReceived(received.toHexString())}
+
+          Delta E: ${printReceived(deltaE)}
+          Epsilon: ${printReceived(epsilon)}`;
+    },
+  };
+}

--- a/packages/auto-palette-wasm/test/matchers/types.ts
+++ b/packages/auto-palette-wasm/test/matchers/types.ts
@@ -1,0 +1,13 @@
+export interface MatcherResult {
+  pass: boolean;
+  message: () => string;
+  actual?: unknown;
+  expected?: unknown;
+}
+
+export type ExpectationResult = MatcherResult | Promise<MatcherResult>;
+
+export interface MatcherState {
+  isNot: boolean;
+  promise: string;
+}

--- a/packages/auto-palette-wasm/test/palette.bench.ts
+++ b/packages/auto-palette-wasm/test/palette.bench.ts
@@ -1,8 +1,8 @@
+import { resolve } from 'node:path';
 import * as AutoPaletteWasm from '@auto-palette/wasm';
 import * as AutoPaletteTs from 'auto-palette';
 import { bench, describe, expect } from 'vitest';
-import { resolve } from 'node:path';
-import { loadImageData } from './image';
+import { loadImageData } from './utils/image';
 
 const IMAGE_PATH = resolve(
   process.cwd(),

--- a/packages/auto-palette-wasm/test/palette.browser.e2e.ts
+++ b/packages/auto-palette-wasm/test/palette.browser.e2e.ts
@@ -1,0 +1,209 @@
+import {
+  type Algorithm,
+  Palette,
+  type Theme,
+  initialize,
+} from '@auto-palette/wasm';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const WASM_PATH = '/dist/auto_palette_bg.wasm';
+const IMAGE_URL =
+  'https://images.unsplash.com/photo-1460751426469-2b744951ebee?ixlib=rb-4.0.3&q=85&fm=jpg&crop=entropy&cs=srgb&w=640';
+
+/**
+ * Load an image from a URL and return a Promise that resolves with the HTMLImageElement.
+ *
+ * @param src - The URL of the image to load.
+ * @returns A Promise that resolves with the loaded HTMLImageElement.
+ */
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.src = src;
+    image.crossOrigin = 'anonymous';
+    image.onload = () => {
+      resolve(image);
+    };
+    image.onerror = reject;
+    image.onabort = reject;
+  });
+}
+
+/**
+ * Create a canvas element with the specified width and height.
+ *
+ * @param width - The width of the canvas.
+ * @param height - The height of the canvas.
+ * @returns The created HTMLCanvasElement.
+ */
+function createCanvas(width: number, height: number): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+/**
+ * Load image data from a URL and return a Promise that resolves with the ImageData.
+ *
+ * @param src - The URL of the image to load.
+ * @returns A Promise that resolves with the loaded ImageData.
+ */
+async function loadImageData(src: string): Promise<ImageData> {
+  const image = await loadImage(src);
+  const canvas = createCanvas(image.width, image.height);
+  const context = canvas.getContext('2d', { alpha: true, colorSpace: 'srgb' });
+  if (!context) {
+    throw new Error('Failed to get canvas context');
+  }
+  context.drawImage(image, 0, 0);
+  return context.getImageData(0, 0, image.width, image.height);
+}
+
+describe('@auto-palette/wasm', () => {
+  describe('initialize', () => {
+    it('should initialize the WebAssembly module from a URL', async () => {
+      // Act
+      const url = new URL(WASM_PATH, window.location.href);
+      await initialize(url);
+
+      // Assert
+      expect(Palette).toBeDefined();
+    });
+
+    it('should initialize the WebAssembly module from a Response', async () => {
+      // Act
+      const response = fetch(WASM_PATH);
+      await initialize(response);
+
+      // Assert
+      expect(Palette).toBeDefined();
+    });
+
+    it('should initialize the WebAssembly module from a BufferSource', async () => {
+      // Act
+      const response = await fetch(WASM_PATH);
+      const buffer = response.arrayBuffer();
+      await initialize(buffer);
+
+      // Assert
+      expect(Palette).toBeDefined();
+    });
+
+    it('should initialize the WebAssembly module from a RequestInfo', async () => {
+      // Act
+      const request = new Request(WASM_PATH);
+      await initialize(request);
+
+      // Assert
+      expect(Palette).toBeDefined();
+    });
+
+    it('should initialize the WebAssembly module from a WebAssembly.Module', async () => {
+      // Act
+      const response = fetch(WASM_PATH);
+      const module = WebAssembly.compileStreaming(response);
+      await initialize(module);
+
+      // Assert
+      expect(Palette).toBeDefined();
+    });
+
+    it.skip('should throw an error if the module cannot be loaded', async () => {
+      // Act & Assert
+      const module = fetch('/dist/unknown.wasm');
+      await expect(initialize(module)).rejects.toThrowError(
+        /Failed to initialize WebAssembly module: /,
+      );
+    });
+  });
+
+  describe('Palette', () => {
+    beforeAll(async () => {
+      const response = fetch(WASM_PATH);
+      await initialize(response);
+    });
+
+    describe('extract', () => {
+      let imageData: ImageData;
+      beforeAll(async () => {
+        // Arrange
+        imageData = await loadImageData(IMAGE_URL);
+      });
+
+      it('should extract the palette from an image', () => {
+        // Act
+        const palette = Palette.extract(imageData);
+
+        // Assert
+        expect(palette.isEmpty()).toBeFalsy();
+        expect(palette.length).toBeGreaterThan(32);
+      });
+
+      it.each([
+        { algorithm: 'dbscan', expectedLength: 48 },
+        { algorithm: 'dbscan++', expectedLength: 72 },
+        { algorithm: 'kmeans', expectedLength: 24 },
+      ])(
+        'should extract the palette from an image with the $algorithm algorithm',
+        ({ algorithm, expectedLength }) => {
+          // Act
+          const palette = Palette.extract(imageData, algorithm as Algorithm);
+
+          // Assert
+          expect(palette.isEmpty()).toBeFalsy();
+          expect(palette.length).toBeGreaterThan(expectedLength);
+        },
+      );
+    });
+
+    describe('findSwatches', () => {
+      let palette: Palette;
+      beforeAll(async () => {
+        // Arrange
+        const imageData = await loadImageData(IMAGE_URL);
+        palette = Palette.extract(imageData, 'dbscan');
+      });
+
+      it('should find the swatches from the palette', () => {
+        // Act
+        const swatches = palette.findSwatches(3);
+
+        // Assert
+        expect(swatches).toHaveLength(3);
+      });
+
+      it.skip.each([
+        {
+          count: 3,
+          theme: 'colorful',
+        },
+        {
+          count: 3,
+          theme: 'vivid',
+        },
+        {
+          count: 3,
+          theme: 'muted',
+        },
+        {
+          count: 3,
+          theme: 'light',
+        },
+        {
+          count: 3,
+          theme: 'dark',
+        },
+      ])(
+        'should find the swatches from the palette with the $theme theme',
+        ({ count, theme }) => {
+          // Act
+          const swatches = palette.findSwatches(count, theme as Theme);
+
+          // Assert
+          expect(swatches).toHaveLength(count);
+        },
+      );
+    });
+  });
+});

--- a/packages/auto-palette-wasm/test/palette.node.e2e.ts
+++ b/packages/auto-palette-wasm/test/palette.node.e2e.ts
@@ -1,0 +1,137 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import {
+  type Algorithm,
+  Palette,
+  type Theme,
+  initialize,
+} from '@auto-palette/wasm';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { loadImageData } from './utils/image';
+
+const WASM_PATH = './dist/auto_palette_bg.wasm';
+const IMAGE_PATH = resolve(
+  process.cwd(),
+  '../../gfx/laura-clugston-pwW2iV9TZao-unsplash.jpg',
+);
+
+describe('@auto-palette/wasm', () => {
+  describe('initialize', () => {
+    it('should initialize the WebAssembly module from a buffer', async () => {
+      // Act
+      const buffer = await readFile(WASM_PATH);
+      await initialize(buffer);
+
+      // Assert
+      expect(Palette).toBeDefined();
+    });
+
+    it.skip('should throw an error if the module cannot be loaded', async () => {
+      // Act & Assert
+      const buffer = readFile('/dist/unknown.wasm');
+      await expect(initialize(buffer)).rejects.toThrowError(
+        /Failed to initialize WebAssembly module: /,
+      );
+    });
+  });
+
+  describe('Palette', () => {
+    beforeAll(async () => {
+      const buffer = await readFile(WASM_PATH);
+      await initialize(buffer);
+    });
+
+    describe('extract', () => {
+      let imageData: ImageData;
+      beforeAll(async () => {
+        // Arrange
+        imageData = await loadImageData(IMAGE_PATH);
+      });
+
+      it('should extract the palette from an image', () => {
+        // Act
+        const palette = Palette.extract(imageData);
+
+        // Assert
+        expect(palette.isEmpty()).toBeFalsy();
+        expect(palette.length).toBeGreaterThan(32);
+      });
+
+      it.each([
+        { algorithm: 'dbscan', expectedLength: 48 },
+        { algorithm: 'dbscan++', expectedLength: 72 },
+        { algorithm: 'kmeans', expectedLength: 24 },
+      ])(
+        'should extract the palette from an image with the $algorithm algorithm',
+        ({ algorithm, expectedLength }) => {
+          // Act
+          const palette = Palette.extract(imageData, algorithm as Algorithm);
+
+          // Assert
+          expect(palette.isEmpty()).toBeFalsy();
+          expect(palette.length).toBeGreaterThan(expectedLength);
+        },
+      );
+    });
+
+    describe('findSwatches', () => {
+      let palette: Palette;
+      beforeAll(async () => {
+        // Arrange
+        const imageData = await loadImageData(IMAGE_PATH);
+        palette = Palette.extract(imageData, 'dbscan');
+      });
+
+      it('should find the swatches from the palette', () => {
+        // Act
+        const swatches = palette.findSwatches(3);
+
+        // Assert
+        expect(swatches).toHaveLength(3);
+        expect(swatches[0].color).toBeSimilarColor('#5ECBFE');
+        expect(swatches[1].color).toBeSimilarColor('#C7101E');
+        expect(swatches[2].color).toBeSimilarColor('#CFC663');
+      });
+
+      it.each([
+        {
+          count: 3,
+          theme: 'colorful',
+          expected: ['#C72C52', '#A48611', '#01B1FC'],
+        },
+        {
+          count: 3,
+          theme: 'vivid',
+          expected: ['#D6314D', '#A48611', '#01B1FC'],
+        },
+        {
+          count: 3,
+          theme: 'muted',
+          expected: ['#04524E', '#CD85B7', '#846E15'],
+        },
+        {
+          count: 3,
+          theme: 'light',
+          expected: ['#5ECBFE', '#CFC663', '#CD85B7'],
+        },
+        {
+          count: 3,
+          theme: 'dark',
+          expected: ['#053E2D', '#032F55', '#4A0117'],
+        },
+      ])(
+        'should find the swatches from the palette with the $theme theme',
+        ({ count, theme, expected }) => {
+          // Act
+          const swatches = palette.findSwatches(count, theme as Theme);
+
+          // Assert
+          expect(swatches).toHaveLength(count);
+          expect(swatches[0].color).toBeSimilarColor(expected[0]);
+          expect(swatches[1].color).toBeSimilarColor(expected[1]);
+          expect(swatches[2].color).toBeSimilarColor(expected[2]);
+        },
+      );
+    });
+  });
+});

--- a/packages/auto-palette-wasm/test/setup.ts
+++ b/packages/auto-palette-wasm/test/setup.ts
@@ -1,7 +1,7 @@
-import { readFile } from 'node:fs/promises';
 import { initialize } from '@auto-palette/wasm';
+import { readFile } from 'node:fs/promises';
 
-const module = await readFile(
+const module = readFile(
   '../../crates/auto-palette-wasm/dist/auto_palette_bg.wasm',
 );
 await initialize(module);

--- a/packages/auto-palette-wasm/test/utils/color.ts
+++ b/packages/auto-palette-wasm/test/utils/color.ts
@@ -1,0 +1,25 @@
+import { Color } from '@auto-palette/wasm';
+
+/**
+ * Parses a value into a Color object.
+ *
+ * @param value - The value to parse.
+ * @return The parsed Color object, or undefined if the value is not a valid color.
+ */
+export function parseColor(value: unknown): Color | undefined {
+  if (value instanceof Color) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    try {
+      return Color.fromHexString(value);
+    } catch (e) {
+      // Ignore the error and return undefined
+      return undefined;
+    }
+  }
+  if (typeof value === 'number') {
+    return Color.fromInt(value);
+  }
+  return undefined;
+}

--- a/packages/auto-palette-wasm/test/utils/image.ts
+++ b/packages/auto-palette-wasm/test/utils/image.ts
@@ -9,7 +9,7 @@ import { createCanvas, loadImage } from '@napi-rs/canvas';
 export async function loadImageData(source: string): Promise<ImageData> {
   const image = await loadImage(source);
   const canvas = createCanvas(image.width, image.height);
-  const context = canvas.getContext('2d');
+  const context = canvas.getContext('2d', { alpha: true, colorSpace: 'srgb' });
   context.drawImage(image, 0, 0);
   return context.getImageData(0, 0, image.width, image.height) as ImageData;
 }

--- a/packages/auto-palette-wasm/vitest.config.ts
+++ b/packages/auto-palette-wasm/vitest.config.ts
@@ -7,9 +7,6 @@ export default defineConfig({
   test: {
     globals: true,
     dir: 'test',
-    include: ['**/*.test.ts'],
-    setupFiles: ['test/setup.ts'],
-    environment: 'node',
     alias: {
       '@auto-palette/core': resolve(
         __dirname,
@@ -17,11 +14,6 @@ export default defineConfig({
       ),
       '@auto-palette/wasm': resolve(__dirname, 'src/index.ts'),
     },
-    benchmark: {
-      include: ['**/*.bench.ts'],
-    },
-    testTimeout: 60_000,
-    retry: 0,
     coverage: {
       all: false,
       provider: 'v8',

--- a/packages/auto-palette-wasm/vitest.workspace.ts
+++ b/packages/auto-palette-wasm/vitest.workspace.ts
@@ -1,0 +1,56 @@
+import { defineWorkspace } from 'vitest/config';
+
+export default defineWorkspace([
+  {
+    extends: './vitest.config.ts',
+    test: {
+      name: 'unit',
+      environment: 'node',
+      include: ['**/*.test.ts'],
+      setupFiles: ['test/setup.ts', 'test/matchers/index.ts'],
+      benchmark: {
+        include: [],
+      },
+      testTimeout: 1000,
+      retry: 0,
+    },
+  },
+  {
+    extends: './vitest.config.ts',
+    test: {
+      name: 'e2e:browser',
+      include: ['**/*.browser.e2e.ts'],
+      setupFiles: ['test/matchers/index.ts'],
+      benchmark: {
+        include: [],
+      },
+      browser: {
+        enabled: true,
+        headless: true,
+        provider: 'playwright',
+        instances: [
+          {
+            browser: 'chromium',
+            screenshotFailures: false,
+          },
+        ],
+      },
+      testTimeout: 600_000,
+      retry: 0,
+    },
+  },
+  {
+    extends: './vitest.config.ts',
+    test: {
+      name: 'e2e:node',
+      environment: 'node',
+      include: ['**/*.node.e2e.ts'],
+      setupFiles: ['test/setup.ts', 'test/matchers/index.ts'],
+      benchmark: {
+        include: ['**/*.bench.ts'],
+      },
+      testTimeout: 600_000,
+      retry: 1,
+    },
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,16 +38,19 @@ importers:
         version: 3.4.1(vite@6.2.5(@types/node@22.14.0)(yaml@2.7.1))
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/node@22.14.0)(@vitest/ui@3.1.1)(yaml@2.7.1)
+        version: 3.1.1(@types/node@22.14.0)(@vitest/browser@3.1.1)(@vitest/ui@3.1.1)(yaml@2.7.1)
 
   packages/auto-palette-wasm:
     devDependencies:
       '@napi-rs/canvas':
         specifier: ^0.1.69
         version: 0.1.69
+      '@vitest/browser':
+        specifier: ^3.1.1
+        version: 3.1.1(playwright@1.51.1)(vite@6.2.5(@types/node@22.14.0)(yaml@2.7.1))(vitest@3.1.1)
       '@vitest/coverage-v8':
         specifier: ^3.1.1
-        version: 3.1.1(vitest@3.1.1)
+        version: 3.1.1(@vitest/browser@3.1.1)(vitest@3.1.1)
       '@vitest/ui':
         specifier: ^3.1.1
         version: 3.1.1(vitest@3.1.1)
@@ -57,6 +60,12 @@ importers:
       esbuild-plugin-copy:
         specifier: ^2.1.1
         version: 2.1.1(esbuild@0.25.2)
+      jest-matcher-utils:
+        specifier: ^29.7.0
+        version: 29.7.0
+      playwright:
+        specifier: ^1.51.1
+        version: 1.51.1
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(postcss@8.5.3)(typescript@5.8.3)(yaml@2.7.1)
@@ -70,6 +79,10 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
@@ -82,6 +95,10 @@ packages:
     resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.27.0':
+    resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.0':
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
@@ -302,6 +319,10 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
@@ -503,15 +524,46 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
   '@taplo/cli@0.7.0':
     resolution: {integrity: sha512-Ck3zFhQhIhi02Hl6T4ZmJsXdnJE+wXcJz5f8klxd4keRYgenMnip3JDPMGDRLbnC/2iGd8P0sBIQqI3KxfVjBg==}
     hasBin: true
+
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
   '@types/node@22.14.0':
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
+
+  '@vitest/browser@3.1.1':
+    resolution: {integrity: sha512-A+A69mMtrj1RPh96LfXGc309KSXhy2MslvyL+cp9+Y5EVdoJD4KfXDx/3SSlRGN70+hIoJ3RRbTidTvj18PZ/A==}
+    peerDependencies:
+      playwright: '*'
+      safaridriver: '*'
+      vitest: 3.1.1
+      webdriverio: ^7.0.0 || ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
 
   '@vitest/coverage-v8@3.1.1':
     resolution: {integrity: sha512-MgV6D2dhpD6Hp/uroUoAIvFqA8AuvXEFBC2eepG3WFc1pxTfdk1LEqqkWoWhjz+rytoqrnUUCdf6Lzco3iHkLQ==}
@@ -572,6 +624,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -582,6 +638,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -721,9 +780,20 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -840,6 +910,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -988,9 +1063,24 @@ packages:
     resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
     engines: {node: 20 || >=22}
 
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -1031,6 +1121,10 @@ packages:
   lru-cache@11.1.0:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
     engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -1197,6 +1291,16 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  playwright-core@1.51.1:
+    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.51.1:
+    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -1219,6 +1323,14 @@ packages:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -1229,6 +1341,12 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -1236,6 +1354,9 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1555,6 +1676,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.18.1:
+    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -1570,6 +1703,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
@@ -1577,6 +1716,10 @@ snapshots:
   '@babel/parser@7.27.0':
     dependencies:
       '@babel/types': 7.27.0
+
+  '@babel/runtime@7.27.0':
+    dependencies:
+      regenerator-runtime: 0.14.1
 
   '@babel/types@7.27.0':
     dependencies:
@@ -1705,6 +1848,10 @@ snapshots:
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@istanbuljs/schema@0.1.3': {}
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
@@ -1843,7 +1990,26 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.39.0':
     optional: true
 
+  '@sinclair/typebox@0.27.8': {}
+
   '@taplo/cli@0.7.0': {}
+
+  '@testing-library/dom@10.4.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/runtime': 7.27.0
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/estree@1.0.7': {}
 
@@ -1851,7 +2017,26 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@vitest/coverage-v8@3.1.1(vitest@3.1.1)':
+  '@vitest/browser@3.1.1(playwright@1.51.1)(vite@6.2.5(@types/node@22.14.0)(yaml@2.7.1))(vitest@3.1.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.1.1(vite@6.2.5(@types/node@22.14.0)(yaml@2.7.1))
+      '@vitest/utils': 3.1.1
+      magic-string: 0.30.17
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.1.1(@types/node@22.14.0)(@vitest/browser@3.1.1)(@vitest/ui@3.1.1)(yaml@2.7.1)
+      ws: 8.18.1
+    optionalDependencies:
+      playwright: 1.51.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.1.1)(vitest@3.1.1)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -1865,7 +2050,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/node@22.14.0)(@vitest/ui@3.1.1)(yaml@2.7.1)
+      vitest: 3.1.1(@types/node@22.14.0)(@vitest/browser@3.1.1)(@vitest/ui@3.1.1)(yaml@2.7.1)
+    optionalDependencies:
+      '@vitest/browser': 3.1.1(playwright@1.51.1)(vite@6.2.5(@types/node@22.14.0)(yaml@2.7.1))(vitest@3.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -1912,7 +2099,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/node@22.14.0)(@vitest/ui@3.1.1)(yaml@2.7.1)
+      vitest: 3.1.1(@types/node@22.14.0)(@vitest/browser@3.1.1)(@vitest/ui@3.1.1)(yaml@2.7.1)
 
   '@vitest/utils@3.1.1':
     dependencies:
@@ -1932,6 +2119,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -1940,6 +2129,10 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-union@2.1.0: {}
 
@@ -2072,9 +2265,15 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
+  diff-sequences@29.6.3: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2214,6 +2413,9 @@ snapshots:
       minipass: 3.3.6
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -2368,7 +2570,25 @@ snapshots:
     dependencies:
       '@isaacs/cliui': 8.0.2
 
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
   joycon@3.1.1: {}
+
+  js-tokens@4.0.0: {}
 
   jsonfile@6.1.0:
     dependencies:
@@ -2421,6 +2641,8 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.1.0: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -2550,6 +2772,14 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  playwright-core@1.51.1: {}
+
+  playwright@1.51.1:
+    dependencies:
+      playwright-core: 1.51.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss-load-config@6.0.1(postcss@8.5.3)(yaml@2.7.1):
     dependencies:
       lilconfig: 3.1.3
@@ -2563,17 +2793,35 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
+  react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
 
   readdirp@4.1.2: {}
+
+  regenerator-runtime@0.14.1: {}
 
   resolve-from@5.0.0: {}
 
@@ -2829,7 +3077,7 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.7.1
 
-  vitest@3.1.1(@types/node@22.14.0)(@vitest/ui@3.1.1)(yaml@2.7.1):
+  vitest@3.1.1(@types/node@22.14.0)(@vitest/browser@3.1.1)(@vitest/ui@3.1.1)(yaml@2.7.1):
     dependencies:
       '@vitest/expect': 3.1.1
       '@vitest/mocker': 3.1.1(vite@6.2.5(@types/node@22.14.0)(yaml@2.7.1))
@@ -2853,6 +3101,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.14.0
+      '@vitest/browser': 3.1.1(playwright@1.51.1)(vite@6.2.5(@types/node@22.14.0)(yaml@2.7.1))(vitest@3.1.1)
       '@vitest/ui': 3.1.1(vitest@3.1.1)
     transitivePeerDependencies:
       - jiti
@@ -2910,6 +3159,8 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
+
+  ws@8.18.1: {}
 
   yallist@4.0.0: {}
 


### PR DESCRIPTION
## Description

In this pull request, browser-based E2E tests and node-based E2E tests for `@auto-palette/wasm` are added.  
These tests ensure the functionality and reliability of the WebAssembly module in both browser and Node.js environments. 

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Palette extraction now delivers six distinct swatches for enhanced color analysis.
  
- **Tests**
  - Expanded coverage with both unit and end-to-end tests across browser and server environments.
  - Added custom validations to improve the accuracy of color comparisons.
  - Introduced new matchers for color comparison, enhancing test capabilities.
  
- **Chores**
  - Updated automation workflows and configurations for more reliable and streamlined testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->