### PR TITLE
Use env variables for Node.js and pnpm versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ permissions:
   contents: read
 
 env:
+  NODE_VERSION: 22.x
+  PNPM_VERSION: 10.8.0
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -209,26 +211,20 @@ jobs:
       - test-wasm
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        node:
-          - 22.x
-        pnpm:
-          - 10.8.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm with ${{ matrix.pnpm }} version
+      - name: Setup pnpm with ${{ env.PNPM_VERSION }} version
         uses: pnpm/action-setup@v4
         with:
-          version: ${{ matrix.pnpm }}
+          version: ${{ env.PNPM_VERSION }}
 
-      - name: Setup Node.js with ${{ matrix.node }} version
+      - name: Setup Node.js with ${{ env.NODE_VERSION }} version
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
           cache: 'pnpm'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Description

In this pull request, the CI workflow is updated to use environment variables for defining the Node.js and pnpm versions.   
This change improves consistency and maintainability across the CI configuration.

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the build configuration for improved version management, enhancing consistency and maintainability in the development pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->