### PR TITLE
Add TypeScript definition for `JsColor` using `typescript_custom_section`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde             = { version = "1.0.117", features = ["derive"] }
 serde_json        = "1.0.117"
 serde_test        = "1.0.117"
 thiserror         = "2.0.12"
-tsify             = "0.4.5"
+tsify             = "0.5.5"
 wasm-bindgen-test = "0.3.50"
 wasm-bindgen      = "0.2.100"
 web-sys           = "0.3.77"

--- a/crates/auto-palette-wasm/src/color.rs
+++ b/crates/auto-palette-wasm/src/color.rs
@@ -1,28 +1,307 @@
 use std::str::FromStr;
 
-use auto_palette::color::{
-    Ansi16,
-    Ansi256,
-    Color,
-    Hue,
-    LCHab,
-    LCHuv,
-    Lab,
-    Luv,
-    Oklab,
-    Oklch,
-    CMYK,
-    HSL,
-    HSV,
-    RGB,
-    XYZ,
-};
-use wasm_bindgen::{prelude::wasm_bindgen, JsError};
+use auto_palette::color::Color;
+use tsify::JsValueSerdeExt;
+use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
+
+/// This section contains the TypeScript definition for the `Color` class.
+#[wasm_bindgen(typescript_custom_section)]
+// language=TypeScript
+const TYPE_DEFINITION: &'static str = r#"
+/**
+ * The hue representation.
+ *
+ * Hue is represented as a number in the range [0, 360).
+ */
+export type Hue = number;
+
+/**
+ * The RGB representation.
+ */
+export interface RGB {
+    r: number;
+    g: number;
+    b: number;
+}
+
+/**
+ * The CMYK representation.
+ */
+export interface CMYK {
+    c: number;
+    m: number;
+    y: number;
+    k: number;
+}
+
+/**
+ * The HSL representation.
+ */
+export interface HSL {
+    h: Hue;
+    s: number;
+    l: number;
+}
+
+/**
+ * The HSV representation.
+ */
+export interface HSV {
+    h: Hue;
+    s: number;
+    v: number;
+}
+
+/**
+ * The XYZ representation.
+ */
+export interface XYZ {
+    x: number;
+    y: number;
+    z: number;
+}
+
+/**
+ * The CIE L*a*b* representation.
+ */
+export interface Lab {
+    l: number;
+    a: number;
+    b: number;
+}
+
+/**
+ * The Oklab representation.
+ */
+export interface Oklab {
+    l: number;
+    a: number;
+    b: number;
+}
+
+/**
+ * The CIE LCHab representation.
+ */
+export interface LCHab {
+    l: number;
+    c: number;
+    h: Hue;
+}
+
+/**
+ * The CIE L*u*v* representation.
+ */
+export interface Luv {
+    l: number;
+    u: number;
+    v: number;
+}
+
+/**
+ * The Oklch representation.
+ */
+export interface Oklch {
+    l: number;
+    c: number;
+    h: Hue;
+}
+
+/**
+ * The CIE LCHuv representation.
+ */
+export interface LCHuv {
+    l: number;
+    c: number;
+    h: Hue;
+}
+
+/**
+ * The ANSI 16 representation.
+ */
+export interface Ansi16 {
+    code: number;
+}
+
+/**
+ * The ANSI 256 representation.
+ */
+export interface Ansi256 {
+    code: number;
+}
+
+/**
+ * The color representation.
+ */
+export class Color {
+    /**
+     * Returns whether the color is light.
+     *
+     * @returns `true` if the color is light, otherwise `false`.
+     */
+    isLight(): boolean;
+
+    /**
+     * Returns whether the color is dark.
+     *
+     * @returns `true` if the color is dark, otherwise `false`.
+     */
+    isDark(): boolean;
+
+    /**
+     * Returns the lightness of the color.
+     *
+     * @returns The lightness of the color.
+     */
+    lightness(): number;
+
+    /**
+     * Returns the chroma of the color.
+     *
+     * @returns The chroma of the color.
+     */
+    chroma(): number;
+
+    /**
+     * Returns the hue of the color.
+     *
+     * @returns The hue of the color.
+     */
+    hue(): Hue;
+
+    /**
+     * Converts the color to RGB format.
+     *
+     * @returns An object containing the RGB values.
+     */
+    toRGB(): RGB;
+
+    /**
+     * Converts the color to CMYK format.
+     *
+     * @returns An object containing the CMYK values.
+     */
+    toCMYK(): CMYK;
+
+    /**
+     * Converts the color to HSL format.
+     *
+     * @returns An object containing the HSL values.
+     */
+    toHSL(): HSL;
+
+    /**
+     * Converts the color to HSV format.
+     *
+     * @returns An object containing the HSV values.
+     */
+    toHSV(): HSV;
+
+    /**
+     * Converts the color to XYZ format.
+     *
+     * @returns An object containing the XYZ values.
+     */
+    toXYZ(): XYZ;
+
+    /**
+     * Converts the color to CIE L*a*b* format.
+     *
+     * @returns An object containing the CIE L*a*b* values.
+     */
+    toLab(): Lab;
+
+    /**
+     * Converts the color to Oklab format.
+     *
+     * @returns An object containing the Oklab values.
+     */
+    toOklab(): Oklab;
+
+    /**
+     * Converts the color to CIE LCHab format.
+     *
+     * @returns An object containing the CIE LCHab values.
+     */
+    toLCHab(): LCHab;
+
+    /**
+     * Converts the color to CIE L*u*v* format.
+     *
+     * @returns An object containing the CIE L*u*v* values.
+     */
+    toLuv(): Luv;
+
+    /**
+     * Converts the color to Oklch format.
+     *
+     * @returns An object containing the Oklch values.
+     */
+    toOklch(): Oklch;
+
+    /**
+     * Converts the color to CIE LCHuv format.
+     *
+     * @returns An object containing the CIE LCHuv values.
+     */
+    toLCHuv(): LCHuv;
+
+    /**
+     * Converts the color to ANSI 16 format.
+     *
+     * @returns An object containing the ANSI 16 values.
+     */
+    toAnsi16(): Ansi16;
+
+    /**
+     * Converts the color to ANSI 256 format.
+     *
+     * @returns An object containing the ANSI 256 values.
+     */
+    toAnsi256(): Ansi256;
+
+    /**
+     * Converts the color to RGB integer format.
+     *
+     * @returns An integer representing the RGB value.
+     */
+    toInt(): number;
+
+    /**
+     * Converts the color to hex string format.
+     *
+     * @returns A string representing the color in hex format.
+     */
+    toHexString(): string;
+
+    /**
+     * Creates a new `Color` instance with the given RGB integer value.
+     *
+     * @param value The RGB integer value representing the color.
+     * @returns A new `Color` instance.
+     */
+    static fromInt(value: number): Color;
+
+    /**
+     * Creates a new `Color` instance with the given hex string.
+     *
+     * Acceptable formats are:
+     * - `#RGB` (e.g., `#f80`)
+     * - `#RGBA` (e.g., `#f80f`)
+     * - `#RRGGBB` (e.g., `#ff8000`)
+     * - `#RRGGBBAA` (e.g., `#ff8000ff`)
+     *
+     * @param string The hex string representing the color.
+     * @returns A new `Color` instance.
+     * @throws Error if the hex string is invalid.
+     */
+    static fromHexString(string: string): Color;
+}
+"#;
 
 /// `JsColor` is a struct for wrapping `Color<f64>` to expose it to JavaScript.
 /// This struct is used to wrap the `Color` type from the auto-palette crate so that it can be used in JavaScript.
 #[derive(Debug, PartialEq, Clone)]
-#[wasm_bindgen(js_name = Color)]
+#[wasm_bindgen(js_name = Color, skip_typescript)]
 pub struct JsColor(pub(crate) Color<f64>);
 
 #[wasm_bindgen(js_class = Color)]
@@ -68,8 +347,9 @@ impl JsColor {
     /// # Returns
     /// The hue of the color.
     #[wasm_bindgen]
-    pub fn hue(&self) -> Hue<f64> {
-        self.0.hue()
+    pub fn hue(&self) -> Result<JsValue, JsError> {
+        let hue = self.0.hue();
+        JsValue::from_serde(&hue).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to RGB format.
@@ -77,8 +357,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the RGB values.
     #[wasm_bindgen(js_name = "toRGB")]
-    pub fn to_rgb(&self) -> RGB {
-        self.0.to_rgb()
+    pub fn to_rgb(&self) -> Result<JsValue, JsError> {
+        let rgb = self.0.to_rgb();
+        JsValue::from_serde(&rgb).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to CMYK format.
@@ -86,8 +367,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the CMYK values.
     #[wasm_bindgen(js_name = "toCMYK")]
-    pub fn to_cmyk(&self) -> CMYK<f64> {
-        self.0.to_cmyk()
+    pub fn to_cmyk(&self) -> Result<JsValue, JsError> {
+        let cmyk = self.0.to_cmyk();
+        JsValue::from_serde(&cmyk).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to HSL format.
@@ -95,8 +377,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the HSL values.
     #[wasm_bindgen(js_name = "toHSL")]
-    pub fn to_hsl(&self) -> HSL<f64> {
-        self.0.to_hsl()
+    pub fn to_hsl(&self) -> Result<JsValue, JsError> {
+        let hsl = self.0.to_hsl();
+        JsValue::from_serde(&hsl).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to HSV format.
@@ -104,8 +387,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the HSV values.
     #[wasm_bindgen(js_name = "toHSV")]
-    pub fn to_hsv(&self) -> HSV<f64> {
-        self.0.to_hsv()
+    pub fn to_hsv(&self) -> Result<JsValue, JsError> {
+        let hsv = self.0.to_hsv();
+        JsValue::from_serde(&hsv).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to XYZ format.
@@ -113,8 +397,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the XYZ values.
     #[wasm_bindgen(js_name = "toXYZ")]
-    pub fn to_xyz(&self) -> XYZ<f64> {
-        self.0.to_xyz()
+    pub fn to_xyz(&self) -> Result<JsValue, JsError> {
+        let xyz = self.0.to_xyz();
+        JsValue::from_serde(&xyz).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to CIE L*a*b* format.
@@ -122,8 +407,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the CIE L*a*b* values.
     #[wasm_bindgen(js_name = "toLab")]
-    pub fn to_lab(&self) -> Lab<f64> {
-        self.0.to_lab()
+    pub fn to_lab(&self) -> Result<JsValue, JsError> {
+        let lab = self.0.to_lab();
+        JsValue::from_serde(&lab).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to Oklab format.
@@ -131,8 +417,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the Oklab values.
     #[wasm_bindgen(js_name = "toOklab")]
-    pub fn to_oklab(&self) -> Oklab<f64> {
-        self.0.to_oklab()
+    pub fn to_oklab(&self) -> Result<JsValue, JsError> {
+        let oklab = self.0.to_oklab();
+        JsValue::from_serde(&oklab).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to CIE LCHab format.
@@ -140,8 +427,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the CIE LCHab values.
     #[wasm_bindgen(js_name = "toLCHab")]
-    pub fn to_lchab(&self) -> LCHab<f64> {
-        self.0.to_lchab()
+    pub fn to_lchab(&self) -> Result<JsValue, JsError> {
+        let lchab = self.0.to_lchab();
+        JsValue::from_serde(&lchab).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to CIE L*u*v* format.
@@ -149,8 +437,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the CIE L*u*v* values.
     #[wasm_bindgen(js_name = "toLuv")]
-    pub fn to_luv(&self) -> Luv<f64> {
-        self.0.to_luv()
+    pub fn to_luv(&self) -> Result<JsValue, JsError> {
+        let luv = self.0.to_luv();
+        JsValue::from_serde(&luv).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to Oklch format.
@@ -158,8 +447,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the Oklch values.
     #[wasm_bindgen(js_name = "toOklch")]
-    pub fn to_oklch(&self) -> Oklch<f64> {
-        self.0.to_oklch()
+    pub fn to_oklch(&self) -> Result<JsValue, JsError> {
+        let oklch = self.0.to_oklch();
+        JsValue::from_serde(&oklch).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to CIE LCHuv format.
@@ -167,8 +457,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the CIE LCHuv values.
     #[wasm_bindgen(js_name = "toLCHuv")]
-    pub fn to_lchuv(&self) -> LCHuv<f64> {
-        self.0.to_lchuv()
+    pub fn to_lchuv(&self) -> Result<JsValue, JsError> {
+        let lchuv = self.0.to_lchuv();
+        JsValue::from_serde(&lchuv).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to ANSI 16 format.
@@ -176,8 +467,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the ANSI 16 values.
     #[wasm_bindgen(js_name = "toAnsi16")]
-    pub fn to_ansi16(&self) -> Ansi16 {
-        self.0.to_ansi16()
+    pub fn to_ansi16(&self) -> Result<JsValue, JsError> {
+        let ansi16 = self.0.to_ansi16();
+        JsValue::from_serde(&ansi16).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to ANSI 256 format.
@@ -185,8 +477,9 @@ impl JsColor {
     /// # Returns
     /// An object containing the ANSI 256 values.
     #[wasm_bindgen(js_name = "toAnsi256")]
-    pub fn to_ansi256(&self) -> Ansi256 {
-        self.0.to_ansi256()
+    pub fn to_ansi256(&self) -> Result<JsValue, JsError> {
+        let ansi256 = self.0.to_ansi256();
+        JsValue::from_serde(&ansi256).map_err(|cause| JsError::new(&cause.to_string()))
     }
 
     /// Converts the color to RGB integer format.
@@ -243,7 +536,25 @@ impl JsColor {
 
 #[cfg(test)]
 mod tests {
-    use auto_palette::assert_approx_eq;
+    use auto_palette::{
+        assert_approx_eq,
+        color::{
+            Ansi16,
+            Ansi256,
+            Hue,
+            LCHab,
+            LCHuv,
+            Lab,
+            Luv,
+            Oklab,
+            Oklch,
+            CMYK,
+            HSL,
+            HSV,
+            RGB,
+            XYZ,
+        },
+    };
     use wasm_bindgen_test::*;
 
     use super::*;
@@ -296,7 +607,8 @@ mod tests {
     fn test_hue() {
         // Arrange
         let color = JsColor::from_int(0xff8000);
-        let actual = color.hue();
+        let value = color.hue().unwrap();
+        let actual = value.into_serde::<Hue>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.to_degrees(), 59.950111);
@@ -306,7 +618,8 @@ mod tests {
     fn test_to_rgb() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_rgb();
+        let value = color.to_rgb().unwrap();
+        let actual = value.into_serde::<RGB>().unwrap();
 
         // Assert
         assert_eq!(
@@ -323,7 +636,8 @@ mod tests {
     fn test_to_cmyk() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_cmyk();
+        let value = color.to_cmyk().unwrap();
+        let actual = value.into_serde::<CMYK>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.c, 0.0, 0.1);
@@ -336,7 +650,8 @@ mod tests {
     fn test_to_hsl() {
         // Act
         let color = JsColor::from_int(0xff0080);
-        let actual = color.to_hsl();
+        let value = color.to_hsl().unwrap();
+        let actual = value.into_serde::<HSL>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.h.to_degrees(), 329.882352);
@@ -348,7 +663,8 @@ mod tests {
     fn test_to_hsv() {
         // Act
         let color = JsColor::from_int(0xff0080);
-        let actual = color.to_hsv();
+        let value = color.to_hsv().unwrap();
+        let actual = value.into_serde::<HSV>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.h.to_degrees(), 329.882352);
@@ -360,7 +676,8 @@ mod tests {
     fn test_to_xyz() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_xyz();
+        let value = color.to_xyz().unwrap();
+        let actual = value.into_serde::<XYZ>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.x, 0.489579);
@@ -372,7 +689,8 @@ mod tests {
     fn test_to_lab() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_lab();
+        let value = color.to_lab().unwrap();
+        let actual = value.into_serde::<Lab>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.l, 67.052536);
@@ -384,7 +702,8 @@ mod tests {
     fn test_to_oklab() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_oklab();
+        let value = color.to_oklab().unwrap();
+        let actual = value.into_serde::<Oklab>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.l, 0.731893);
@@ -396,7 +715,8 @@ mod tests {
     fn test_to_lchab() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_lchab();
+        let value = color.to_lchab().unwrap();
+        let actual = value.into_serde::<LCHab>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.l, 67.052536);
@@ -408,7 +728,8 @@ mod tests {
     fn test_to_luv() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_luv();
+        let value = color.to_luv().unwrap();
+        let actual = value.into_serde::<Luv>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.l, 67.052536);
@@ -420,7 +741,8 @@ mod tests {
     fn test_to_oklch() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_oklch();
+        let value = color.to_oklch().unwrap();
+        let actual = value.into_serde::<Oklch>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.l, 0.731893);
@@ -432,7 +754,8 @@ mod tests {
     fn test_to_lchuv() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_lchuv();
+        let value = color.to_lchuv().unwrap();
+        let actual = value.into_serde::<LCHuv>().unwrap();
 
         // Assert
         assert_approx_eq!(actual.l, 67.052536);
@@ -444,7 +767,8 @@ mod tests {
     fn test_to_ansi16() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_ansi16();
+        let value = color.to_ansi16().unwrap();
+        let actual = value.into_serde::<Ansi16>().unwrap();
 
         // Assert
         assert_eq!(actual, Ansi16::bright_yellow());
@@ -454,7 +778,8 @@ mod tests {
     fn test_to_ansi256() {
         // Act
         let color = JsColor::from_int(0xff8000);
-        let actual = color.to_ansi256();
+        let value = color.to_ansi256().unwrap();
+        let actual = value.into_serde::<Ansi256>().unwrap();
 
         // Assert
         assert_eq!(actual, Ansi256::new(208));

--- a/crates/auto-palette-wasm/src/position.rs
+++ b/crates/auto-palette-wasm/src/position.rs
@@ -70,10 +70,20 @@ mod tests {
     fn test_tsify() {
         // Assert
         let expected = indoc! {
-            "export interface Position {
-                x: number;
-                y: number;
-            }"
+            // language=TypeScript
+            "/**
+              * The position representation of a swatch.
+              */
+             export interface JsPosition {
+                 /**
+                  * The x coordinate of the swatch.
+                  */
+                 x: number;
+                 /**
+                  * The y coordinate of the swatch.
+                  */
+                 y: number;
+             }"
         };
         assert_eq!(JsPosition::DECL, expected);
     }

--- a/crates/auto-palette/Cargo.toml
+++ b/crates/auto-palette/Cargo.toml
@@ -18,26 +18,23 @@ rust-version = "1.84.0"
 [features]
 default = ["image"]
 image   = ["dep:image"]
-wasm    = ["getrandom/wasm_js", "dep:serde", "dep:tsify", "dep:wasm-bindgen"]
+wasm    = ["getrandom/wasm_js", "dep:serde"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
 
 [dependencies]
-getrandom    = { workspace = true }
-image        = { workspace = true, optional = true }
-num-traits   = { workspace = true }
-rand         = { workspace = true }
-rand_distr   = { workspace = true }
-serde        = { workspace = true, optional = true }
-thiserror    = { workspace = true }
-tsify        = { workspace = true, optional = true }
-wasm-bindgen = { workspace = true, optional = true }
+getrandom  = { workspace = true }
+image      = { workspace = true, optional = true }
+num-traits = { workspace = true }
+rand       = { workspace = true }
+rand_distr = { workspace = true }
+serde      = { workspace = true, optional = true }
+thiserror  = { workspace = true }
 
 [dev-dependencies]
 anyhow     = { workspace = true }
 image      = { workspace = true, features = ["jpeg", "png"] }
-indoc      = { workspace = true }
 rstest     = { workspace = true }
 serde_test = { workspace = true }
 

--- a/crates/auto-palette/src/color/ansi16.rs
+++ b/crates/auto-palette/src/color/ansi16.rs
@@ -2,8 +2,6 @@ use std::fmt::{Display, Formatter};
 
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::color::{error::ColorError, RGB};
 
@@ -24,8 +22,7 @@ use crate::color::{error::ColorError, RGB};
 /// assert_eq!(format!("{}", ansi16), "ANSI16(92)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct Ansi16 {
     /// The ANSI 16 color code.
     pub(crate) code: u8,
@@ -261,8 +258,6 @@ fn from_rgb(r: u8, g: u8, b: u8) -> u8 {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -341,18 +336,6 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Act & Assert
-        let expected = indoc! {
-            "export interface Ansi16 {
-                code: number;
-            }"
-        };
-        assert_eq!(Ansi16::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/ansi256.rs
+++ b/crates/auto-palette/src/color/ansi256.rs
@@ -5,8 +5,6 @@ use std::{
 
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::color::{Ansi16, RGB};
 
@@ -25,8 +23,7 @@ use crate::color::{Ansi16, RGB};
 /// assert_eq!(format!("{}", ansi256), "ANSI256(41)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct Ansi256 {
     code: u8,
 }
@@ -105,8 +102,6 @@ fn from_rgb(r: u8, g: u8, b: u8) -> u8 {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -166,18 +161,6 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Act & Assert
-        let expected = indoc! {
-            "export interface Ansi256 {
-                code: number;
-            }"
-        };
-        assert_eq!(Ansi256::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/cmyk.rs
+++ b/crates/auto-palette/src/color/cmyk.rs
@@ -3,8 +3,6 @@ use std::fmt::{Display, Formatter};
 use num_traits::clamp;
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{color::RGB, FloatNumber};
 
@@ -31,19 +29,14 @@ use crate::{color::RGB, FloatNumber};
 /// assert_eq!(format!("{}", cmyk), "CMYK(0.00, 0.00, 1.00, 0.00)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct CMYK<T = f64>
 where
     T: FloatNumber,
 {
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub c: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub m: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub y: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub k: T,
 }
 
@@ -110,8 +103,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -207,22 +198,6 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Assert
-        let expected = indoc! {
-            // language=typescript
-            "export interface CMYK<T> {
-                c: number;
-                m: number;
-                y: number;
-                k: number;
-            }"
-        };
-        assert_eq!(CMYK::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/hsl.rs
+++ b/crates/auto-palette/src/color/hsl.rs
@@ -3,8 +3,6 @@ use std::fmt::Display;
 use num_traits::clamp;
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{
     color::{hue::Hue, rgb::RGB},
@@ -33,17 +31,13 @@ use crate::{
 /// assert_eq!(format!("{}", hsl), "HSL(60.00, 1.00, 0.50)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct HSL<T = f64>
 where
     T: FloatNumber,
 {
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub h: Hue<T>,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub s: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub l: T,
 }
 
@@ -116,8 +110,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -205,21 +197,6 @@ mod tests {
                 Token::StructEnd,
             ],
         )
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Assert
-        let expected = indoc! {
-            // language=typescript
-            "export interface HSL<T> {
-                h: number;
-                s: number;
-                l: number;
-            }"
-        };
-        assert_eq!(HSL::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/hsv.rs
+++ b/crates/auto-palette/src/color/hsv.rs
@@ -3,8 +3,6 @@ use std::fmt::Display;
 use num_traits::clamp;
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{
     color::{hue::Hue, RGB},
@@ -33,17 +31,13 @@ use crate::{
 /// assert_eq!(format!("{}", hsv), "HSV(60.00, 1.00, 1.00)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct HSV<T = f64>
 where
     T: FloatNumber,
 {
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub h: Hue<T>,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub s: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub v: T,
 }
 
@@ -119,8 +113,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -207,21 +199,6 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Assert
-        let expected = indoc! {
-            // language=typescript
-            "export interface HSV<T> {
-                h: number;
-                s: number;
-                v: number;
-            }"
-        };
-        assert_eq!(HSV::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/hue.rs
+++ b/crates/auto-palette/src/color/hue.rs
@@ -2,8 +2,6 @@ use std::fmt::Display;
 
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::math::FloatNumber;
 
@@ -24,9 +22,7 @@ use crate::math::FloatNumber;
 /// assert_eq!(format!("{}", hue), "240.00");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct Hue<T = f64>(#[cfg_attr(feature = "wasm", tsify(type = "number"))] T)
+pub struct Hue<T = f64>(T)
 where
     T: FloatNumber;
 
@@ -139,8 +135,6 @@ where
 mod tests {
     use std::f64::consts::PI;
 
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -211,17 +205,6 @@ mod tests {
 
         // Assert
         assert_de_tokens(&hue, &[Token::F64(60.0)]);
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Assert
-        let expected = indoc! {
-            // language=typescript
-            "export type Hue<T> = number;"
-        };
-        assert_eq!(Hue::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/lab.rs
+++ b/crates/auto-palette/src/color/lab.rs
@@ -3,8 +3,6 @@ use std::{fmt::Display, marker::PhantomData};
 use num_traits::clamp;
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{
     color::{white_point::WhitePoint, LCHab, D65, XYZ},
@@ -37,18 +35,14 @@ use crate::{
 /// assert_eq!(format!("{}", lchab), "LCH(ab)(87.74, 119.78, 136.02)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct Lab<T = f64, W = D65>
 where
     T: FloatNumber,
     W: WhitePoint,
 {
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub l: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub a: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub b: T,
     #[cfg_attr(feature = "wasm", serde(skip))]
     _marker: PhantomData<W>,
@@ -242,8 +236,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -310,21 +302,6 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Act & Assert
-        let expected = indoc! {
-            // language=typescript
-            "export interface Lab<T> {
-                l: number;
-                a: number;
-                b: number;
-            }"
-        };
-        assert_eq!(Lab::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/lchab.rs
+++ b/crates/auto-palette/src/color/lchab.rs
@@ -3,8 +3,6 @@ use std::{fmt::Display, marker::PhantomData};
 use num_traits::clamp;
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{
     color::{Hue, Lab, WhitePoint, D65},
@@ -36,18 +34,14 @@ use crate::{
 /// assert_eq!(format!("{}", lab), "Lab(54.62, 81.55, 42.92)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct LCHab<T = f64, W = D65>
 where
     T: FloatNumber,
     W: WhitePoint,
 {
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub l: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub c: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub h: Hue<T>,
     #[cfg_attr(feature = "wasm", serde(skip))]
     _marker: PhantomData<W>,
@@ -111,8 +105,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
 
@@ -184,21 +176,6 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Act & Assert
-        let expected = indoc! {
-            // language=typescript
-            "export interface LCHab<T> {
-                l: number;
-                c: number;
-                h: number;
-            }"
-        };
-        assert_eq!(LCHab::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/lchuv.rs
+++ b/crates/auto-palette/src/color/lchuv.rs
@@ -3,8 +3,6 @@ use std::{fmt::Display, marker::PhantomData};
 use num_traits::clamp;
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{
     color::{Hue, Luv, WhitePoint, D65},
@@ -36,18 +34,14 @@ use crate::{
 /// assert_eq!(format!("{}", luv), "Luv(56.23, -46.00, 21.73)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct LCHuv<T = f64, W = D65>
 where
     T: FloatNumber,
     W: WhitePoint,
 {
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub l: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub c: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub h: Hue<T>,
     #[cfg_attr(feature = "wasm", serde(skip))]
     _marker: PhantomData<W>,
@@ -111,8 +105,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
 
@@ -184,21 +176,6 @@ mod tests {
                 Token::StructEnd,
             ],
         )
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Act & Assert
-        let expected = indoc! {
-            // language=typescript
-            "export interface LCHuv<T> {
-                l: number;
-                c: number;
-                h: number;
-            }"
-        };
-        assert_eq!(LCHuv::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/luv.rs
+++ b/crates/auto-palette/src/color/luv.rs
@@ -3,8 +3,6 @@ use std::{fmt::Display, marker::PhantomData};
 use num_traits::clamp;
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{
     color::{white_point::WhitePoint, LCHuv, D65, XYZ},
@@ -36,18 +34,14 @@ use crate::{
 /// assert_eq!(format!("{}", lchuv), "LCH(uv)(53.64, 167.62, 8.29)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct Luv<T = f64, W = D65>
 where
     T: FloatNumber,
     W: WhitePoint,
 {
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub l: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub u: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub v: T,
     #[cfg_attr(feature = "wasm", serde(skip))]
     _marker: PhantomData<W>,
@@ -154,8 +148,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -244,21 +236,6 @@ mod tests {
                 Token::StructEnd,
             ],
         )
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Act & Assert
-        let expected = indoc! {
-            // language=typescript
-            "export interface Luv<T> {
-                l: number;
-                u: number;
-                v: number;
-            }"
-        };
-        assert_eq!(Luv::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/oklab.rs
+++ b/crates/auto-palette/src/color/oklab.rs
@@ -1,8 +1,6 @@
 use num_traits::clamp;
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{
     color::{oklch::Oklch, XYZ},
@@ -33,17 +31,13 @@ use crate::{
 /// assert_eq!(format!("{}", xyz), "XYZ(0.15, 0.24, 0.20)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct Oklab<T = f64>
 where
     T: FloatNumber,
 {
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub l: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub a: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub b: T,
 }
 
@@ -124,8 +118,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_tokens, Token};
@@ -197,21 +189,6 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Act & Assert
-        let expected = indoc! {
-            // language=typescript
-            "export interface Oklab<T> {
-                l: number;
-                a: number;
-                b: number;
-            }"
-        };
-        assert_eq!(Oklab::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/oklch.rs
+++ b/crates/auto-palette/src/color/oklch.rs
@@ -3,8 +3,6 @@ use std::fmt::Display;
 use num_traits::clamp;
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{
     color::{Hue, Oklab},
@@ -35,17 +33,13 @@ use crate::{
 /// assert_eq!(format!("{}", oklab), "Oklab(0.61, -0.12, 0.03)");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct Oklch<T = f64>
 where
     T: FloatNumber,
 {
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub l: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub c: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub h: Hue<T>,
 }
 
@@ -103,8 +97,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
 
@@ -175,21 +167,6 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Act & Assert
-        let expected = indoc! {
-            // language=ts
-            "export interface Oklch<T> {
-                l: number;
-                c: number;
-                h: number;
-            }"
-        };
-        assert_eq!(Oklch::<f64>::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/rgb.rs
+++ b/crates/auto-palette/src/color/rgb.rs
@@ -2,8 +2,6 @@ use std::{fmt, fmt::Display};
 
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{
     color::{hsl::HSL, xyz::XYZ, HSV},
@@ -37,8 +35,7 @@ use crate::{
 /// assert_eq!(format!("{}", xyz), "XYZ(0.42, 0.22, 0.07)");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct RGB {
     pub r: u8,
     pub g: u8,
@@ -223,8 +220,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -290,21 +285,6 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Act & Assert
-        let expected = indoc! {
-            // language=ts
-            "export interface RGB {
-                r: number;
-                g: number;
-                b: number;
-            }"
-        };
-        assert_eq!(RGB::DECL, expected);
     }
 
     #[test]

--- a/crates/auto-palette/src/color/xyz.rs
+++ b/crates/auto-palette/src/color/xyz.rs
@@ -3,8 +3,6 @@ use std::fmt::Display;
 use num_traits::clamp;
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
 
 use crate::{
     color::{lab::Lab, luv::Luv, rgb::RGB, white_point::WhitePoint, Oklab},
@@ -39,17 +37,13 @@ use crate::{
 /// assert_eq!(format!("{}", oklab), "Oklab(0.70, 0.27, -0.17)");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub struct XYZ<T = f64>
 where
     T: FloatNumber,
 {
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub x: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub y: T,
-    #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     pub z: T,
 }
 
@@ -326,8 +320,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "wasm")]
-    use indoc::indoc;
     use rstest::rstest;
     #[cfg(feature = "wasm")]
     use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
@@ -394,21 +386,6 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wasm")]
-    fn test_tsify() {
-        // Act & Assert
-        let expected = indoc! {
-            // language=ts
-            "export interface XYZ<T> {
-                x: number;
-                y: number;
-                z: number;
-            }"
-        };
-        assert_eq!(XYZ::<f64>::DECL, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Added a TypeScript definition for the `JsColor` struct using the `typescript_custom_section` feature in `wasm_bindgen`.  
 
This change enables better TypeScript support for the `JsColor` struct in the WASM module.


## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced TypeScript support for color-related WebAssembly bindings by providing custom TypeScript interface definitions for color types.

- **Refactor**
  - Improved JavaScript interoperability by serializing color conversion results to JavaScript-compatible values and updating method return types.
  - Shifted to explicit serialization-based interfaces for WASM bindings.

- **Chores**
  - Removed the `tsify` dependency and related automatic TypeScript interface generation from color type implementations and tests.
  - Updated dependency versions and cleaned up unused dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->