### PR TITLE
Improve safety and readability by replacing unsafe unwrap/expect with `Result` for clustering algorithms

### DIFF
--- a/crates/auto-palette/src/math/clustering/algorithm.rs
+++ b/crates/auto-palette/src/math/clustering/algorithm.rs
@@ -9,6 +9,9 @@ pub trait ClusteringAlgorithm<T, const N: usize>
 where
     T: FloatNumber,
 {
+    /// The error type for the clustering algorithm.
+    type Err;
+
     /// Fits the clustering algorithm to the given points.
     ///
     /// # Arguments
@@ -16,5 +19,5 @@ where
     ///
     /// # Returns
     /// The clusters of the points.
-    fn fit(&self, points: &[Point<T, N>]) -> Vec<Cluster<T, N>>;
+    fn fit(&self, points: &[Point<T, N>]) -> Result<Vec<Cluster<T, N>>, Self::Err>;
 }

--- a/crates/auto-palette/src/math/clustering/kmeans.rs
+++ b/crates/auto-palette/src/math/clustering/kmeans.rs
@@ -1,7 +1,8 @@
-use std::collections::HashSet;
+use std::{cmp::Ordering, collections::HashSet, fmt::Display};
 
 use rand::{distr::Distribution, Rng};
-use rand_distr::weighted::{AliasableWeight, WeightedAliasIndex};
+use rand_distr::weighted::{AliasableWeight, Error as WeightedAliasIndexError, WeightedAliasIndex};
+use thiserror::Error;
 
 use crate::math::{
     clustering::{Cluster, ClusteringAlgorithm},
@@ -10,6 +11,33 @@ use crate::math::{
     point::Point,
     FloatNumber,
 };
+
+/// K-means clustering algorithm error type.
+#[derive(Debug, PartialEq, Error)]
+pub enum KmeansError<T>
+where
+    T: FloatNumber + Display,
+{
+    /// Error when the number of clusters is invalid.
+    #[error("Invalid Cluster Count: The number of clusters must be > 0: {0}")]
+    InvalidClusterCount(usize),
+
+    /// Error when the number of iterations is invalid.
+    #[error("Invalid Iterations: The number of iterations must be > 0: {0}")]
+    InvalidIterations(usize),
+
+    /// Error when the tolerance is invalid.
+    #[error("Invalid Tolerance: The tolerance must be > 0: {0}")]
+    InvalidTolerance(T),
+
+    /// Error when the distance metric is invalid.
+    #[error("Weighted Alias Index Error: {0}")]
+    WeightedAliasIndexError(#[from] WeightedAliasIndexError),
+
+    /// Error when the points is empty.
+    #[error("Empty Points: The points must be non-empty.")]
+    EmptyPoints,
+}
 
 /// K-means clustering algorithm.
 ///
@@ -45,25 +73,21 @@ where
     ///
     /// # Returns
     /// A new `Kmeans` instance.
-    ///
-    /// # Errors
-    /// Returns an error if the number of clusters is zero, the maximum number of iterations is zero,
-    /// or the tolerance is less than or equal to zero.
     pub fn new(
         k: usize,
         max_iter: usize,
         tolerance: T,
         metric: DistanceMetric,
         rng: R,
-    ) -> Result<Self, &'static str> {
+    ) -> Result<Self, KmeansError<T>> {
         if k == 0 {
-            return Err("The number of clusters must be greater than zero.");
+            return Err(KmeansError::InvalidClusterCount(k));
         }
         if max_iter == 0 {
-            return Err("The maximum number of iterations must be greater than zero.");
+            return Err(KmeansError::InvalidIterations(max_iter));
         }
         if tolerance <= T::zero() {
-            return Err("The tolerance must be greater than zero.");
+            return Err(KmeansError::InvalidTolerance(tolerance));
         }
         Ok(Self {
             k,
@@ -74,40 +98,49 @@ where
         })
     }
 
-    fn initialize<const N: usize>(&self, points: &[Point<T, N>], k: usize) -> Vec<Point<T, N>>
+    fn initialize<const N: usize>(
+        &self,
+        points: &[Point<T, N>],
+        k: usize,
+    ) -> Result<Vec<Point<T, N>>, KmeansError<T>>
     where
         T: FloatNumber + AliasableWeight,
         R: Rng,
     {
         let mut selected = HashSet::with_capacity(k);
         let mut centroids = Vec::with_capacity(k);
-
         let mut rng = self.rng.clone();
+
+        // 1. Randomly select the first centroid from the data points.
         let index = rng.random_range(0..points.len());
         selected.insert(index);
         centroids.push(points[index]);
 
+        // 2. For each remaining centroid, select the point with the maximum distance from the existing centroids.
         while centroids.len() < k {
-            let mut distances = Vec::with_capacity(points.len());
-            for (i, point) in points.iter().enumerate() {
-                let distance = if selected.contains(&i) {
-                    T::zero()
-                } else {
-                    centroids
-                        .iter()
-                        .map(|centroid| self.metric.measure(centroid, point))
-                        .min_by(|a, b| a.partial_cmp(b).unwrap())
-                        .unwrap()
-                };
-                distances.push(distance);
-            }
+            let distances: Vec<T> = points
+                .iter()
+                .enumerate()
+                .map(|(index, point)| {
+                    if selected.contains(&index) {
+                        T::zero()
+                    } else {
+                        centroids
+                            .iter()
+                            .map(|centroid| self.metric.measure(centroid, point))
+                            .min_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal))
+                            .unwrap_or(T::epsilon()) // Use an epsilon value to avoid zero distance
+                    }
+                })
+                .collect();
 
-            let weighted_index = WeightedAliasIndex::new(distances).unwrap();
+            let weighted_index =
+                WeightedAliasIndex::new(distances).map_err(KmeansError::WeightedAliasIndexError)?;
             let index = weighted_index.sample(&mut rng);
             selected.insert(index);
             centroids.push(points[index]);
         }
-        centroids
+        Ok(centroids)
     }
 
     #[must_use]
@@ -117,28 +150,23 @@ where
         centroids: &mut [Point<T, N>],
         clusters: &mut [Cluster<T, N>],
     ) -> bool {
-        for cluster in clusters.iter_mut() {
-            cluster.clear();
-        }
+        clusters.iter_mut().for_each(Cluster::clear);
 
-        let centroid_search = LinearSearch::build(centroids, self.metric.clone());
+        let centroid_search = LinearSearch::build(centroids, self.metric);
         for (index, point) in points.iter().enumerate() {
-            let nearest = centroid_search
-                .search_nearest(point)
-                .expect("No nearest centroid found.");
-            clusters[nearest.index].add_member(index, point);
-        }
-
-        let mut converged = true;
-        let new_centroids: Vec<Point<T, N>> =
-            clusters.iter().map(|cluster| *cluster.centroid()).collect();
-        for (old, new) in centroids.iter().zip(&new_centroids) {
-            let distance = self.metric.measure(old, new);
-            if distance > self.tolerance {
-                converged = false;
-                break;
+            if let Some(nearest) = centroid_search.search_nearest(point) {
+                clusters[nearest.index].add_member(index, point);
             }
         }
+
+        let new_centroids: Vec<Point<T, N>> =
+            clusters.iter().map(|cluster| *cluster.centroid()).collect();
+
+        let converged = centroids
+            .iter()
+            .zip(&new_centroids)
+            .all(|(old, new)| self.metric.measure(old, new) <= self.tolerance);
+
         centroids.copy_from_slice(&new_centroids);
         converged
     }
@@ -149,13 +177,15 @@ where
     T: FloatNumber + AliasableWeight,
     R: Rng + Clone,
 {
-    fn fit(&self, points: &[Point<T, N>]) -> Vec<Cluster<T, N>> {
+    type Err = KmeansError<T>;
+
+    fn fit(&self, points: &[Point<T, N>]) -> Result<Vec<Cluster<T, N>>, Self::Err> {
         if points.is_empty() {
-            return Vec::new();
+            return Err(KmeansError::EmptyPoints);
         }
 
         if self.k >= points.len() {
-            return points
+            let clusters = points
                 .iter()
                 .enumerate()
                 .map(|(index, point)| {
@@ -164,9 +194,10 @@ where
                     cluster
                 })
                 .collect();
+            return Ok(clusters);
         }
 
-        let mut centroids = self.initialize(points, self.k);
+        let mut centroids = self.initialize(points, self.k)?;
         let mut clusters = vec![Cluster::new(); self.k];
         for _ in 0..self.max_iter {
             let converged = self.iterate(points, &mut centroids, &mut clusters);
@@ -174,7 +205,7 @@ where
                 break;
             }
         }
-        clusters
+        Ok(clusters)
     }
 }
 
@@ -204,28 +235,28 @@ mod tests {
         10,
         1e-3,
         DistanceMetric::Euclidean,
-        "The number of clusters must be greater than zero."
+        KmeansError::InvalidClusterCount(0)
     )]
     #[case::invalid_iterations(
         3,
         0,
         1e-3,
         DistanceMetric::Euclidean,
-        "The maximum number of iterations must be greater than zero."
+        KmeansError::InvalidIterations(0)
     )]
     #[case::invalid_tolerance(
         3,
         10,
         0.0,
         DistanceMetric::Euclidean,
-        "The tolerance must be greater than zero."
+        KmeansError::InvalidTolerance(0.0)
     )]
     fn test_new_error(
         #[case] k: usize,
         #[case] max_iter: usize,
         #[case] tolerance: f32,
         #[case] metric: DistanceMetric,
-        #[case] expected: &'static str,
+        #[case] expected: KmeansError<f32>,
     ) {
         // Act
         let actual = KMeans::new(k, max_iter, tolerance, metric, rng());
@@ -255,21 +286,8 @@ mod tests {
         let actual = kmeans.fit(&points);
 
         // Assert
-        assert_eq!(actual.len(), 3);
-    }
-
-    #[test]
-    fn test_fit_empty() {
-        // Arrange
-        let metric = DistanceMetric::Euclidean;
-        let kmeans: KMeans<f32, ThreadRng> = KMeans::new(3, 10, 1e-3, metric, rng()).unwrap();
-
-        // Act
-        let points: Vec<Point<f32, 2>> = Vec::new();
-        let actual = kmeans.fit(&points);
-
-        // Assert
-        assert_eq!(actual.len(), 0);
+        assert!(actual.is_ok());
+        assert_eq!(actual.unwrap().len(), 3);
     }
 
     #[test]
@@ -283,6 +301,22 @@ mod tests {
         let actual = kmeans.fit(&points);
 
         // Assert
-        assert_eq!(actual.len(), 3);
+        assert!(actual.is_ok());
+        assert_eq!(actual.unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_fit_empty() {
+        // Arrange
+        let metric = DistanceMetric::Euclidean;
+        let kmeans: KMeans<f32, ThreadRng> = KMeans::new(3, 10, 1e-3, metric, rng()).unwrap();
+
+        // Act
+        let points: Vec<Point<f32, 2>> = Vec::new();
+        let actual = kmeans.fit(&points);
+
+        // Assert
+        assert!(actual.is_err());
+        assert_eq!(actual.unwrap_err(), KmeansError::EmptyPoints);
     }
 }

--- a/crates/auto-palette/src/math/metrics.rs
+++ b/crates/auto-palette/src/math/metrics.rs
@@ -5,7 +5,7 @@ use crate::math::{point::Point, FloatNumber};
 /// DistanceMetric enum used to measure the distance between two points.
 ///
 /// This enum provides different methods to calculate distance between points in an N-dimensional space.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum DistanceMetric {
     /// The Euclidean distance, used to measure the straight-line distance between two points.
     #[default]
@@ -34,8 +34,8 @@ impl DistanceMetric {
         T: FloatNumber,
     {
         match self {
-            DistanceMetric::Euclidean => measure_squared_euclidean(point1, point2).sqrt(),
-            DistanceMetric::SquaredEuclidean => measure_squared_euclidean(point1, point2),
+            DistanceMetric::Euclidean => squared_euclidean(point1, point2).sqrt(),
+            DistanceMetric::SquaredEuclidean => squared_euclidean(point1, point2),
         }
     }
 }
@@ -56,7 +56,7 @@ impl DistanceMetric {
 /// The squared Euclidean distance between the two points.
 #[inline]
 #[must_use]
-fn measure_squared_euclidean<T, const N: usize>(point1: &Point<T, N>, point2: &Point<T, N>) -> T
+fn squared_euclidean<T, const N: usize>(point1: &Point<T, N>, point2: &Point<T, N>) -> T
 where
     T: FloatNumber,
 {

--- a/crates/auto-palette/tests/palette.rs
+++ b/crates/auto-palette/tests/palette.rs
@@ -16,9 +16,12 @@ where
 {
     // Act
     let image_data = ImageData::load(path).unwrap();
-    let palette: Palette<f32> = Palette::extract(&image_data).unwrap();
+    let actual: Result<Palette<f64>, _> = Palette::extract(&image_data);
 
     // Assert
+    assert!(actual.is_ok());
+
+    let palette = actual.unwrap();
     assert_eq!(palette.len(), 1);
 
     let swatches = palette.swatches();
@@ -29,19 +32,28 @@ where
 fn test_extract_empty() {
     // Act
     let image_data = ImageData::load("../../gfx/colors/transparent.png").unwrap();
-    let palette: Palette<f32> = Palette::extract(&image_data).unwrap();
+    let actual: Result<Palette<f64>, _> = Palette::extract(&image_data);
 
     // Assert
-    assert_eq!(palette.len(), 0);
+    assert!(actual.is_err());
+
+    let error = actual.err().unwrap();
+    assert_eq!(
+        error.to_string(),
+        "Image data is empty: no pixels to process"
+    );
 }
 
 #[test]
 fn test_extract_multiple_colors() {
     // Act
     let image_data = ImageData::load("../../gfx/olympic_logo.png").unwrap();
-    let palette: Palette<f32> = Palette::extract(&image_data).unwrap();
+    let actual: Result<Palette<f64>, _> = Palette::extract(&image_data);
 
     // Assert
+    assert!(actual.is_ok());
+
+    let palette = actual.unwrap();
     assert_eq!(palette.len(), 6);
 }
 
@@ -55,9 +67,12 @@ fn test_extract_with_algorithm(#[case] name: &str) {
     let algorithm = Algorithm::from_str(name).unwrap();
 
     // Act
-    let palette: Palette<f32> = Palette::extract_with_algorithm(&image_data, algorithm).unwrap();
+    let actual: Result<Palette<f64>, _> = Palette::extract_with_algorithm(&image_data, algorithm);
 
     // Assert
+    assert!(actual.is_ok());
+
+    let palette = actual.unwrap();
     assert!(!palette.is_empty());
     assert!(palette.len() >= 6);
 }
@@ -74,11 +89,13 @@ where
 {
     // Act
     let image_data = ImageData::load(path).unwrap();
-    let palette: Palette<f32> = Palette::extract(&image_data).unwrap();
-    let swatches = palette.find_swatches(n).unwrap();
+    let palette: Palette<f64> = Palette::extract(&image_data).unwrap();
+    let actual = palette.find_swatches(n);
 
     // Assert
-    assert!(!palette.is_empty());
+    assert!(actual.is_ok());
+
+    let swatches = actual.unwrap();
     assert_eq!(swatches.len(), n);
 
     let colors: Vec<_> = swatches
@@ -88,16 +105,4 @@ where
     for expected_color in expected {
         assert!(colors.contains(&expected_color.to_string()));
     }
-}
-
-#[test]
-fn test_find_swatches_with_empty_palette() {
-    // Act
-    let image_data = ImageData::load("../../gfx/colors/transparent.png").unwrap();
-    let palette: Palette<f32> = Palette::extract(&image_data).unwrap();
-    let swatches = palette.find_swatches(5).unwrap();
-
-    // Assert
-    assert!(palette.is_empty());
-    assert!(swatches.is_empty());
 }

--- a/packages/auto-palette-wasm/test/palette.test.ts
+++ b/packages/auto-palette-wasm/test/palette.test.ts
@@ -144,20 +144,20 @@ describe('@auto-palette/wasm/palette', () => {
 
       // Assert
       expect(actual).toHaveLength(3);
-      expect(actual[0].color).toBeSameColor('#FF6F61');
+      expect(actual[0].color).toBeSameColor('#6DE1D2');
       expect(actual[1].color).toBeSameColor('#FFD63A');
-      expect(actual[2].color).toBeSameColor('#6DE1D2');
+      expect(actual[2].color).toBeSameColor('#FF6F61');
     });
 
     it.each([
-      { theme: 'vivid', count: 3, expected: ['#4F1C51', '#FFD63A', '#FF6F61'] },
-      { theme: 'muted', count: 3, expected: ['#A27B5C', '#3F4F44', '#604652'] },
-      { theme: 'light', count: 3, expected: ['#6DE1D2', '#F7CFD8', '#FF6F61'] },
-      { theme: 'dark', count: 3, expected: ['#604652', '#210F37', '#3F4F44'] },
+      { theme: 'vivid', count: 3, expected: ['#FFD63A', '#4F1C51', '#FF6F61'] },
+      { theme: 'muted', count: 3, expected: ['#604652', '#A27B5C', '#3F4F44'] },
+      { theme: 'light', count: 3, expected: ['#6DE1D2', '#FF6F61', '#F7CFD8'] },
+      { theme: 'dark', count: 3, expected: ['#210F37', '#3F4F44', '#604652'] },
       {
         theme: 'colorful',
         count: 3,
-        expected: ['#FF6F61', '#6DE1D2', '#4F1C51'],
+        expected: ['#4F1C51', '#FF6F61', '#6DE1D2'],
       },
     ])(
       'should find the swatches from the palette with $theme theme',


### PR DESCRIPTION
## Description

This pull request refactors the clustering algorithms under the `math/clustering` module to improve safety and readability.   
Specifically, it replaces unsafe `unwrap` and `expect` calls with the `Result` type for error handling.  
This change ensures safer code execution and enhances maintainability.

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
