### PR TITLE
Add PaletteBuilder for customizable palette extraction with algorithms, filters, and other options

### DIFF
--- a/crates/auto-palette-cli/src/main.rs
+++ b/crates/auto-palette-cli/src/main.rs
@@ -58,7 +58,11 @@ fn main() -> anyhow::Result<()> {
 
     let instant = Instant::now();
     let algorithm = Algorithm::from(context.args().algorithm);
-    let Ok(palette) = Palette::<f32>::extract_with_algorithm(&image_data, algorithm) else {
+    let Ok(palette) = Palette::<f32>::builder()
+        .algorithm(algorithm)
+        .filter(|pixel| pixel[3] == 0)
+        .build(&image_data)
+    else {
         process::exit(1);
     };
 

--- a/crates/auto-palette-wasm/src/palette.rs
+++ b/crates/auto-palette-wasm/src/palette.rs
@@ -151,7 +151,10 @@ impl JsPalette {
             .map(Algorithm::try_from)
             .unwrap_or(Ok(Algorithm::DBSCAN))?;
 
-        let palette = Palette::extract_with_algorithm(&image_data, algorithm)
+        let palette = Palette::builder()
+            .algorithm(algorithm)
+            .filter(|pixel| pixel[3] == 0)
+            .build(&image_data)
             .map_err(|e| JsError::new(&format!("Failed to extract palette from image: {}", e)))?;
         Ok(Self(palette))
     }

--- a/crates/auto-palette/README.md
+++ b/crates/auto-palette/README.md
@@ -135,16 +135,20 @@ let palette: Palette<f64> = Palette::extract(&image_data).unwrap();
 
 <a id="palette-extract-with-algorithm"></a>
 
-#### `Palette::extract_with_algorithm`
+#### `Palette::builder`
 
-Extracts the color palette from the given `ImageData` with the specified `Algorithm`.
-The supported algorithms are `DBSCAN`, `DBSCAN++`, and `KMeans++`.
+Creates a new `PaletteBuilder` instance to customize the palette extraction process.
+This method allows you to specify the algorithm, color filter, and other options.
 
 ```rust
 // Load the image data from the file
 let image_data = ImageData::load("path/to/image.jpg").unwrap();
 // Extract the color palette from the image data with the specified algorithm
-let palette: Palette<f64> = Palette::extract_with_algorithm(&image_data, Algorithm::DBSCAN).unwrap();
+let palette: Palette<f64> = Palette::builder()
+    .algorithm(Algorithm::DBSCANpp)
+    .color_filter(|pixel| pixel[0] > 128 && pixel[1] > 128 && pixel[2] > 128)
+    .build(&image_data)
+    .unwrap();
 ```
 
 <a id="palette-find-swatches"></a>

--- a/crates/auto-palette/examples/algorithm.rs
+++ b/crates/auto-palette/examples/algorithm.rs
@@ -25,7 +25,10 @@ fn main() -> Result<(), Error> {
 
     // Extract the palette from the image data
     let start = Instant::now();
-    let palette: Palette<f32> = Palette::extract_with_algorithm(&image_data, algorithm)
+    let palette: Palette<f32> = Palette::builder()
+        .algorithm(algorithm)
+        .filter(|pixel| pixel[3] == 0)
+        .build(&image_data)
         .with_context(|| "Failed to extract the palette from the image data")?;
     let duration = start.elapsed();
     println!(

--- a/crates/auto-palette/src/lib.rs
+++ b/crates/auto-palette/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(coverage_attribute)]
+#![feature(array_chunks, coverage_attribute)]
 
 mod algorithm;
 mod assert;


### PR DESCRIPTION
## Description

In this pull request, the `PaletteBuilder` is introduced to enable customizable palette extraction. This builder pattern allows users to specify algorithms, filters, and other options for extracting color palettes, making the process more flexible and user-friendly.

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
