### PR TITLE
fix: update GitHub Action's workflow permissions to resolve code scanning alert

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * *' # At the end of every day
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   fossa:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Update the `FOSSA` workflow to include the required `permissions` field to resolve the "Workflow does not contain permissions" code scanning alert. This ensures compliance with GitHub's security recommendations.

## Related Issue

https://github.com/t28hub/auto-palette/security/code-scanning/1

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other: Security

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
