### PR TITLE
feat: implement SNIC (Simple Non-Iterative Clustering) algorithm for color palette extraction

### DIFF
--- a/crates/auto-palette/src/math/clustering/helper.rs
+++ b/crates/auto-palette/src/math/clustering/helper.rs
@@ -1,0 +1,166 @@
+use crate::{
+    math::{matrix::MatrixView, DistanceMetric},
+    FloatNumber,
+};
+
+/// Measures the gradient at a given point.
+///
+/// # Type Parameters
+/// * `N` - The number of dimensions.
+///
+/// # Arguments
+/// * `matrix` - The matrix of points.
+/// * `col` - The column of the point.
+/// * `row` - The row of the point.
+/// * `metric` - The distance metric to use.
+///
+/// # Returns
+/// The gradient at the given point. If the point is out of bounds, returns `T::max_value()`.
+#[inline]
+#[must_use]
+pub fn gradient<T, const N: usize>(
+    matrix: &MatrixView<'_, T, N>,
+    col: usize,
+    row: usize,
+    metric: DistanceMetric,
+) -> T
+where
+    T: FloatNumber,
+{
+    if col == 0 || col == matrix.cols - 1 {
+        return T::max_value();
+    }
+    if row == 0 || row == matrix.rows - 1 {
+        return T::max_value();
+    }
+
+    let dx = axis_gradient(matrix, col - 1, row, col + 1, row, metric);
+    let dy = axis_gradient(matrix, col, row - 1, col, row + 1, metric);
+    dx + dy
+}
+
+/// Measures the gradient of the axis between two points.
+///
+/// # Type Parameters
+/// * `N` - The number of dimensions.
+///
+/// # Arguments
+/// * `matrix` - The matrix of points.
+/// * `col1` - The column of the first point.
+/// * `row1` - The row of the first point.
+/// * `col2` - The column of the second point.
+/// * `row2` - The row of the second point.
+/// * `metric` - The distance metric to use.
+///
+/// # Returns
+/// The gradient of the axis between the two points. If either point is out of bounds, returns `T::max_value()`.
+#[inline(always)]
+#[must_use]
+fn axis_gradient<T, const N: usize>(
+    matrix: &MatrixView<'_, T, N>,
+    col1: usize,
+    row1: usize,
+    col2: usize,
+    row2: usize,
+    metric: DistanceMetric,
+) -> T
+where
+    T: FloatNumber,
+{
+    match (matrix.get(col1, row1), matrix.get(col2, row2)) {
+        (Some(point1), Some(point2)) => metric.measure(point1, point2),
+        _ => T::max_value(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::{
+        assert_approx_eq,
+        math::{matrix::MatrixView, Point},
+    };
+
+    #[must_use]
+    fn sample_points<T>(cols: usize, rows: usize) -> Vec<Point<T, 5>>
+    where
+        T: FloatNumber,
+    {
+        let half_cols = cols / 2;
+        let half_rows = rows / 2;
+
+        let mut points = vec![[T::zero(); 5]; cols * rows];
+        for col in 0..cols {
+            for row in 0..rows {
+                let index = col + row * cols;
+                let x = T::from_usize(col + 1) / T::from_usize(cols);
+                let y = T::from_usize(row + 1) / T::from_usize(rows);
+                points[index] = if col < half_cols && row < half_rows {
+                    [T::one(), T::zero(), T::zero(), x, y]
+                } else if col >= half_cols && row < half_rows {
+                    [T::zero(), T::one(), T::zero(), x, y]
+                } else if col < half_cols && row >= half_rows {
+                    [T::zero(), T::zero(), T::one(), x, y]
+                } else {
+                    [T::one(), T::one(), T::one(), x, y]
+                };
+            }
+        }
+        points
+    }
+
+    #[rstest]
+    #[case::left_top(0, 0, f64::MAX)]
+    #[case::right_top(23, 0, f64::MAX)]
+    #[case::left_bottom(0, 11, f64::MAX)]
+    #[case::right_bottom(23, 11, f64::MAX)]
+    #[case::edge_x(12, 3, 2.034722)]
+    #[case::edge_y(18, 6, 2.034722)]
+    #[case::center(12, 6, 4.034722)]
+    #[case::normal(6, 3, 0.034722)]
+    fn test_gradient(#[case] col: usize, #[case] row: usize, #[case] expected: f64) {
+        // Arrange
+        let cols = 24;
+        let rows = 12;
+        let points = sample_points::<f64>(cols, rows);
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = gradient(&matrix, col, row, DistanceMetric::SquaredEuclidean);
+
+        // Assert
+        assert_approx_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::x_axis((0, 0), (1, 0), 0.001736)]
+    #[case::y_axis((23, 0), (23, 1), 0.003906)]
+    #[case::x_axis_out_of_bounds((23, 0), (24,0), f64::MAX)]
+    #[case::y_axis_out_of_bounds((0, 16), (0, 17), f64::MAX)]
+    fn test_axis_gradient(
+        #[case] (col1, row1): (usize, usize),
+        #[case] (col2, row2): (usize, usize),
+        #[case] expected: f64,
+    ) {
+        // Arrange
+        let cols = 24;
+        let rows = 16;
+        let points = sample_points::<f64>(cols, rows);
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = axis_gradient(
+            &matrix,
+            col1,
+            row1,
+            col2,
+            row2,
+            DistanceMetric::SquaredEuclidean,
+        );
+
+        // Assert
+        assert_approx_eq!(actual, expected);
+    }
+}

--- a/crates/auto-palette/src/math/clustering/initializer.rs
+++ b/crates/auto-palette/src/math/clustering/initializer.rs
@@ -1,0 +1,160 @@
+use std::collections::HashSet;
+
+use crate::{math::matrix::MatrixView, FloatNumber};
+
+/// Seed initializer for clustering algorithms.
+#[derive(Debug)]
+pub enum Initializer {
+    /// Seed initializer using a grid pattern.
+    Grid,
+}
+
+impl Initializer {
+    /// Initializes the seeds for clustering.
+    ///
+    /// # Type Parameters
+    /// * `T` - The floating point type.
+    /// * `N` - The number of dimensions.
+    ///
+    /// # Arguments
+    /// * `matrix` - The matrix of points.
+    /// * `k` - The number of seeds to initialize.
+    ///
+    /// # Returns
+    /// A set of indices representing the seeds for clustering.
+    #[must_use]
+    pub fn initialize<T, const N: usize>(
+        &self,
+        matrix: &MatrixView<'_, T, N>,
+        k: usize,
+    ) -> HashSet<usize>
+    where
+        T: FloatNumber,
+    {
+        if k == 0 {
+            return HashSet::new();
+        }
+
+        if k > matrix.size() {
+            return HashSet::from_iter(0..matrix.size());
+        }
+
+        match self {
+            Self::Grid => self.initialize_grid(matrix, k),
+        }
+    }
+
+    /// Initializes the seeds using a grid pattern.
+    ///
+    /// # Type Parameters
+    /// * `T` - The floating point type.
+    /// * `N` - The number of dimensions.
+    ///
+    /// # Arguments
+    /// * `matrix` - The matrix of points.
+    /// * `k` - The number of seeds to initialize.
+    ///
+    /// # Returns
+    /// A set of indices representing the seeds for clustering.
+    #[must_use]
+    fn initialize_grid<T, const N: usize>(
+        &self,
+        matrix: &MatrixView<'_, T, N>,
+        k: usize,
+    ) -> HashSet<usize>
+    where
+        T: FloatNumber,
+    {
+        let step = (T::from_usize(matrix.size()) / T::from_usize(k))
+            .sqrt()
+            .round()
+            .trunc_to_usize()
+            .max(1); // Ensure step is at least 1
+        let offset = step / 2;
+
+        let (cols, rows) = matrix.shape();
+        let mut seeds = HashSet::with_capacity(k);
+        'outer: for i in (offset..cols).step_by(step) {
+            'inner: for j in (offset..rows).step_by(step) {
+                let col = i.min(cols - 1);
+                let row = j.min(rows - 1);
+                let index = match matrix.index(col, row) {
+                    Some(index) => index,
+                    None => continue 'inner,
+                };
+
+                seeds.insert(index);
+                if seeds.len() >= k {
+                    break 'outer;
+                }
+            }
+        }
+        seeds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::math::{matrix::MatrixView, Point};
+
+    #[must_use]
+    fn sample_points<T>(cols: usize, rows: usize) -> Vec<Point<T, 2>>
+    where
+        T: FloatNumber,
+    {
+        vec![[T::zero(); 2]; cols * rows]
+    }
+
+    #[rstest]
+    #[case(1, vec![65])] // (5, 5)
+    #[case(2, vec![39, 46])] // (3, 3), (10, 3)
+    #[case(4, vec![26, 31, 86, 91])] // (2, 2), (7, 2), (2, 7), (7, 7)
+    #[case(6, vec![26, 30, 34, 74, 78, 82])] // (2, 2), (6, 2), (10, 2), (2, 6), (6, 6), (10, 6)
+    fn test_initialize_grid(#[case] k: usize, #[case] expected: Vec<usize>) {
+        // Arrange
+        let cols = 12;
+        let rows = 9;
+        let points = sample_points::<f64>(cols, rows);
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = Initializer::Grid.initialize(&matrix, k);
+
+        // Assert
+        assert_eq!(actual.len(), expected.len());
+        assert_eq!(actual, HashSet::from_iter(expected));
+    }
+
+    #[test]
+    fn test_initialize_zero_seeds() {
+        // Arrange
+        let cols = 4;
+        let rows = 9;
+        let points = sample_points::<f64>(cols, rows);
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = Initializer::Grid.initialize(&matrix, 0);
+
+        // Assert
+        assert_eq!(actual.len(), 0);
+    }
+
+    #[test]
+    fn test_initialize_too_many_seeds() {
+        // Arrange
+        let cols = 4;
+        let rows = 9;
+        let points = sample_points::<f64>(cols, rows);
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = Initializer::Grid.initialize(&matrix, cols * rows + 1);
+
+        // Assert
+        assert_eq!(actual.len(), 36);
+    }
+}

--- a/crates/auto-palette/src/math/clustering/mod.rs
+++ b/crates/auto-palette/src/math/clustering/mod.rs
@@ -2,12 +2,17 @@ mod algorithm;
 mod cluster;
 mod dbscan;
 mod dbscanpp;
+mod helper;
+mod initializer;
 mod kmeans;
 mod slic;
+mod snic;
 
 pub use algorithm::ClusteringAlgorithm;
 pub use cluster::Cluster;
 pub use dbscan::DBSCAN;
 pub use dbscanpp::DBSCANPlusPlus;
+pub use initializer::Initializer;
 pub use kmeans::KMeans;
 pub use slic::SLIC;
+pub use snic::SNIC;

--- a/crates/auto-palette/src/math/clustering/snic.rs
+++ b/crates/auto-palette/src/math/clustering/snic.rs
@@ -1,0 +1,488 @@
+use std::{
+    cmp::{Ordering, Reverse},
+    collections::BinaryHeap,
+    marker::PhantomData,
+};
+
+use thiserror::Error;
+
+use crate::{
+    math::{
+        clustering::{helper::gradient, Cluster, ClusteringAlgorithm, Initializer},
+        matrix::{MatrixError, MatrixView},
+        DistanceMetric,
+        Point,
+    },
+    FloatNumber,
+};
+
+/// SNIC algorithm error type.
+///
+/// # Type Parameters
+/// * `T` - The floating point type.
+#[derive(Debug, PartialEq, Error)]
+pub enum SNICError {
+    /// Error when the shape is invalid.
+    #[error("Invalid Shape: The shape must be > 0: {0}x{1}")]
+    InvalidShape(usize, usize),
+
+    /// Error when the number of segments is invalid.
+    #[error("Invalid Segments: The number of segments must be > 0: {0}")]
+    InvalidSegments(usize),
+
+    /// Error when the points are empty.
+    #[error("Empty Points: The points must be non-empty.")]
+    EmptyPoints,
+
+    /// Error when the points are not in the expected shape.
+    #[error("Invalid Points: The points slice is not in the expected shape: {0}")]
+    InvalidPoints(#[from] MatrixError),
+}
+
+/// SNIC (Simple Non-Iterative Clustering) algorithm.
+///
+/// This implementation is based on the following paper:
+/// [Superpixels and Polygons using Simple Non-Iterative Clustering](https://openaccess.thecvf.com/content_cvpr_2017/papers/Achanta_Superpixels_and_Polygons_CVPR_2017_paper.pdf)
+///
+/// # Type Parameters
+/// * `T` - The floating point type.
+#[derive(Debug, PartialEq)]
+#[allow(clippy::upper_case_acronyms)]
+pub struct SNIC<T>
+where
+    T: FloatNumber,
+{
+    shape: (usize, usize),
+    segments: usize,
+    metric: DistanceMetric,
+    _marker: PhantomData<T>,
+}
+
+impl<T> SNIC<T>
+where
+    T: FloatNumber,
+{
+    /// The label for unclassified points.
+    const LABEL_UNCLASSIFIED: usize = usize::MAX;
+
+    /// Creates a new `SNIC` instance.
+    ///
+    /// # Arguments
+    /// * `shape` - The shape of the points to cluster as a tuple of (cols, rows).
+    /// * `segments` - The number of segments to create.
+    /// * `metric` - The distance metric to use.
+    ///
+    /// # Returns
+    /// A new `SNIC` instance.
+    pub fn new(
+        shape: (usize, usize),
+        segments: usize,
+        metric: DistanceMetric,
+    ) -> Result<Self, SNICError> {
+        if shape.0 == 0 || shape.1 == 0 {
+            return Err(SNICError::InvalidShape(shape.0, shape.1));
+        }
+        if segments == 0 {
+            return Err(SNICError::InvalidSegments(segments));
+        }
+        Ok(Self {
+            shape,
+            segments,
+            metric,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Finds the index of the lowest gradient point in the matrix.
+    ///
+    /// # Type Parameters
+    /// * `N` - The number of dimensions.
+    ///
+    /// # Arguments
+    /// * `matrix` - The matrix of points.
+    /// * `index` - The index of the point to check.
+    ///
+    /// # Returns
+    /// The index of the point with the lowest gradient in the neighborhood if it exists.
+    #[must_use]
+    fn find_lowest_gradient_index<const N: usize>(
+        &self,
+        matrix: &MatrixView<T, N>,
+        index: usize,
+    ) -> Option<usize> {
+        let col = index % matrix.cols;
+        let row = index / matrix.cols;
+
+        let mut lowest_score = T::max_value();
+        let mut lowest_index = None;
+        matrix
+            .neighbor_indices(col, row)
+            .iter()
+            .for_each(|neighbor_index| {
+                let neighbor_col = neighbor_index % matrix.cols;
+                let neighbor_row = neighbor_index / matrix.cols;
+                let score = gradient(matrix, neighbor_col, neighbor_row, self.metric);
+                if score < lowest_score {
+                    lowest_score = score;
+                    lowest_index = Some(*neighbor_index);
+                }
+            });
+        lowest_index
+    }
+}
+
+impl<T, const N: usize> ClusteringAlgorithm<T, N> for SNIC<T>
+where
+    T: FloatNumber,
+{
+    type Err = SNICError;
+
+    fn fit(&self, points: &[Point<T, N>]) -> Result<Vec<Cluster<T, N>>, Self::Err> {
+        if points.is_empty() {
+            return Err(SNICError::EmptyPoints);
+        }
+
+        let (cols, rows) = self.shape;
+        let matrix = MatrixView::new(cols, rows, points)?;
+
+        // 1. Initialize the seeds using a grid pattern.
+        let seeds = Initializer::Grid
+            .initialize(&matrix, self.segments)
+            .into_iter()
+            .map(|seed_index| {
+                let found = self.find_lowest_gradient_index(&matrix, seed_index);
+                found.unwrap_or(seed_index)
+            })
+            .collect::<Vec<_>>();
+
+        // 2. Initialize the priority queue with the seeds.
+        let mut clusters = vec![Cluster::new(); seeds.len()];
+        let mut queue = seeds.into_iter().enumerate().fold(
+            BinaryHeap::with_capacity(matrix.size()),
+            |mut heap, (cluster_label, point_index)| {
+                let element = Element {
+                    col: point_index % cols,
+                    row: point_index / cols,
+                    distance: T::zero(),
+                    cluster_label,
+                };
+                heap.push(Reverse(element));
+                heap
+            },
+        );
+
+        // 3. Main clustering loop
+        let mut labels = vec![Self::LABEL_UNCLASSIFIED; matrix.size()];
+        while let Some(Reverse(element)) = queue.pop() {
+            let point_index = element.col + element.row * cols;
+            // Skip if the point is already assigned to a cluster.
+            if labels[point_index] != Self::LABEL_UNCLASSIFIED {
+                continue;
+            }
+
+            // Assign the nearest cluster label to the point.
+            let cluster_label = element.cluster_label;
+            labels[point_index] = cluster_label;
+
+            let cluster = &mut clusters[cluster_label];
+            cluster.add_member(point_index, &points[point_index]);
+
+            // Traverse the neighbors of the point and add them as candidates for clustering.
+            let centroid = cluster.centroid();
+            matrix
+                .neighbor_indices(element.col, element.row)
+                .into_iter()
+                .filter(|&neighbor_index| labels[neighbor_index] == Self::LABEL_UNCLASSIFIED)
+                .for_each(|neighbor_index| {
+                    let distance = self.metric.measure(centroid, &points[neighbor_index]);
+                    let element = Element {
+                        cluster_label,
+                        col: neighbor_index % cols,
+                        row: neighbor_index / cols,
+                        distance,
+                    };
+                    queue.push(Reverse(element));
+                });
+        }
+        Ok(clusters)
+    }
+}
+
+/// An element representing a candidate for clustering.
+///
+/// # Type Parameters
+/// * `T` - The floating point type.
+#[derive(Debug)]
+struct Element<T>
+where
+    T: FloatNumber,
+{
+    /// The column index of the element.
+    col: usize,
+
+    /// The row index of the element.
+    row: usize,
+
+    /// The distance of the element from the cluster centroid.
+    distance: T,
+
+    /// The cluster label of the element.
+    cluster_label: usize,
+}
+
+impl<T> PartialEq for Element<T>
+where
+    T: FloatNumber,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.cluster_label == other.cluster_label
+            && self.distance == other.distance
+            && self.col == other.col
+            && self.row == other.row
+    }
+}
+
+impl<T> Eq for Element<T> where T: FloatNumber {}
+
+impl<T> PartialOrd for Element<T>
+where
+    T: FloatNumber,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for Element<T>
+where
+    T: FloatNumber,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.distance
+            .partial_cmp(&other.distance)
+            .unwrap_or(Ordering::Less)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[must_use]
+    fn sample_points<T>(cols: usize, rows: usize) -> Vec<Point<T, 5>>
+    where
+        T: FloatNumber,
+    {
+        let half_cols = cols / 2;
+        let half_rows = rows / 2;
+
+        let mut points = vec![[T::zero(); 5]; cols * rows];
+        for col in 0..cols {
+            for row in 0..rows {
+                let index = col + row * cols;
+                let x = T::from_usize(col + 1) / T::from_usize(cols);
+                let y = T::from_usize(row + 1) / T::from_usize(rows);
+                points[index] = if col < half_cols && row < half_rows {
+                    [T::one(), T::zero(), T::zero(), x, y]
+                } else if col >= half_cols && row < half_rows {
+                    [T::zero(), T::one(), T::zero(), x, y]
+                } else if col < half_cols && row >= half_rows {
+                    [T::zero(), T::zero(), T::one(), x, y]
+                } else {
+                    [T::zero(), T::zero(), T::zero(), x, y]
+                };
+            }
+        }
+        points
+    }
+
+    #[must_use]
+    fn empty_points<T>() -> Vec<Point<T, 5>>
+    where
+        T: FloatNumber,
+    {
+        Vec::new()
+    }
+
+    #[test]
+    fn test_new() {
+        // Arrange
+        let shape = (32, 18);
+        let segments = 12;
+        let metric = DistanceMetric::Euclidean;
+
+        // Act
+        let actual = SNIC::<f64>::new(shape, segments, metric);
+
+        // Assert
+        assert!(actual.is_ok());
+        assert_eq!(
+            actual.unwrap(),
+            SNIC {
+                shape,
+                segments,
+                metric,
+                _marker: PhantomData,
+            }
+        );
+    }
+
+    #[rstest]
+    #[case::invalid_shape_cols((0, 18), 12, DistanceMetric::Euclidean, SNICError::InvalidShape(0, 18))]
+    #[case::invalid_shape_rows((32, 0), 12, DistanceMetric::Euclidean, SNICError::InvalidShape(32, 0))]
+    #[case::invalid_segments((32, 18), 0, DistanceMetric::Euclidean, SNICError::InvalidSegments(0))]
+    fn test_new_error(
+        #[case] shape: (usize, usize),
+        #[case] segments: usize,
+        #[case] metric: DistanceMetric,
+        #[case] expected: SNICError,
+    ) {
+        // Act
+        let actual = SNIC::<f64>::new(shape, segments, metric);
+
+        // Assert
+        assert!(actual.is_err());
+        assert_eq!(actual.unwrap_err(), expected);
+    }
+
+    #[test]
+    fn test_fit() {
+        // Arrange
+        let cols = 32;
+        let rows = 18;
+        let segments = 12;
+        let snic =
+            SNIC::<f64>::new((cols, rows), segments, DistanceMetric::SquaredEuclidean).unwrap();
+
+        // Act
+        let points = sample_points::<f64>(cols, rows);
+        let actual = snic.fit(&points);
+
+        // Assert
+        assert!(actual.is_ok());
+        let clusters = actual.unwrap();
+        assert_eq!(clusters.len(), segments);
+    }
+
+    #[test]
+    fn test_fit_empty_points() {
+        // Arrange
+        let snic = SNIC::<f64>::new((32, 18), 12, DistanceMetric::SquaredEuclidean).unwrap();
+
+        // Act
+        let points = empty_points::<f64>();
+        let actual = snic.fit(&points);
+
+        // Assert
+        assert!(actual.is_err());
+        assert_eq!(actual.unwrap_err(), SNICError::EmptyPoints);
+    }
+
+    #[test]
+    fn test_fit_invalid_points() {
+        // Arrange
+        let cols = 32;
+        let rows = 18;
+        let snic = SNIC::<f64>::new((cols, rows), 12, DistanceMetric::SquaredEuclidean).unwrap();
+
+        // Act
+        let points = sample_points(cols - 1, rows);
+        let actual = snic.fit(&points);
+
+        // Assert
+        assert!(actual.is_err());
+        assert_eq!(
+            actual.unwrap_err(),
+            SNICError::InvalidPoints(MatrixError::InvalidPoints(cols, rows))
+        );
+    }
+
+    #[test]
+    fn test_element_eq() {
+        // Arrange
+        let element1 = Element {
+            col: 1,
+            row: 2,
+            distance: 3.0,
+            cluster_label: 4,
+        };
+        let element2 = Element {
+            col: 1,
+            row: 2,
+            distance: 3.0,
+            cluster_label: 4,
+        };
+
+        // Act & Assert
+        assert_eq!(element1, element2);
+    }
+
+    #[test]
+    fn test_element_cmp() {
+        // Arrange
+        let element1 = Element {
+            col: 1,
+            row: 2,
+            distance: 3.0,
+            cluster_label: 4,
+        };
+        let element2 = Element {
+            col: 1,
+            row: 2,
+            distance: 4.0,
+            cluster_label: 4,
+        };
+
+        // Act & Assert
+        assert_eq!(element1.cmp(&element1), Ordering::Equal);
+        assert_eq!(element2.cmp(&element2), Ordering::Equal);
+        assert_eq!(element1.cmp(&element2), Ordering::Less);
+        assert_eq!(element2.cmp(&element1), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_element_partial_cmp() {
+        // Arrange
+        let element1 = Element {
+            col: 1,
+            row: 2,
+            distance: 3.0,
+            cluster_label: 4,
+        };
+        let element2 = Element {
+            col: 1,
+            row: 2,
+            distance: 4.0,
+            cluster_label: 4,
+        };
+
+        // Act & Assert
+        assert_eq!(element1.partial_cmp(&element1), Some(Ordering::Equal));
+        assert_eq!(element2.partial_cmp(&element2), Some(Ordering::Equal));
+        assert_eq!(element1.partial_cmp(&element2), Some(Ordering::Less));
+        assert_eq!(element2.partial_cmp(&element1), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_cmp_nan() {
+        // Arrange
+        let element1 = Element {
+            col: 1,
+            row: 2,
+            distance: 3.0,
+            cluster_label: 4,
+        };
+        let element2 = Element {
+            col: 1,
+            row: 2,
+            distance: f64::NAN,
+            cluster_label: 4,
+        };
+
+        // Act & Assert
+        assert_eq!(element1.cmp(&element2), Ordering::Less);
+        assert_eq!(element2.cmp(&element1), Ordering::Less);
+    }
+}

--- a/crates/auto-palette/src/math/matrix.rs
+++ b/crates/auto-palette/src/math/matrix.rs
@@ -1,0 +1,352 @@
+use std::collections::HashSet;
+
+use thiserror::Error;
+
+use crate::{math::Point, FloatNumber};
+
+/// Error type for the `MatrixView` struct.
+#[derive(Debug, PartialEq, Error)]
+pub enum MatrixError {
+    /// Error when the shape of the matrix is invalid.
+    #[error("Invalid Shape: The shape must be > 0: {0}x{1}")]
+    InvalidShape(usize, usize),
+
+    /// Error when the points slice is not in the expected shape.
+    #[error("Invalid Points: The points slice is not in the expected shape: {0}x{1}.")]
+    InvalidPoints(usize, usize),
+}
+
+/// Lightweight, read-only view over a matrix of points.
+///
+/// `MatrixView` does NOT own the points, it only keeps a slice reference to them, making it cheap to copy.
+///
+/// # Type Parameters
+/// * `T` - The floating point type.
+/// * `N` - The number of dimensions.
+#[derive(Debug, PartialEq)]
+pub struct MatrixView<'a, T, const N: usize>
+where
+    T: FloatNumber,
+{
+    /// The number of columns in the matrix.
+    pub(super) cols: usize,
+
+    /// The number of rows in the matrix.
+    pub(super) rows: usize,
+
+    /// The points in the matrix.
+    points: &'a [Point<T, N>],
+}
+
+impl<'a, T, const N: usize> MatrixView<'a, T, N>
+where
+    T: FloatNumber,
+{
+    /// Creates a new `MatrixView` instance.
+    ///
+    /// # Arguments
+    /// * `cols` - The number of columns in the matrix.
+    /// * `rows` - The number of rows in the matrix.
+    /// * `points` - The points to view.
+    ///
+    /// # Returns
+    /// A new `MatrixView` instance.
+    #[inline]
+    pub fn new(cols: usize, rows: usize, points: &'a [Point<T, N>]) -> Result<Self, MatrixError> {
+        if cols == 0 || rows == 0 {
+            return Err(MatrixError::InvalidShape(cols, rows));
+        }
+
+        if cols * rows != points.len() {
+            return Err(MatrixError::InvalidPoints(cols, rows));
+        }
+        Ok(Self { cols, rows, points })
+    }
+
+    /// Returns the size of the matrix.
+    ///
+    /// # Returns
+    /// The size of the matrix.
+    #[inline(always)]
+    #[must_use]
+    pub fn size(&self) -> usize {
+        self.points.len()
+    }
+
+    /// Returns the shape of the matrix.
+    ///
+    /// # Returns
+    /// The shape of the matrix.
+    #[inline]
+    #[must_use]
+    pub fn shape(&self) -> (usize, usize) {
+        (self.cols, self.rows)
+    }
+
+    /// Returns the flattened index of the given column and row.
+    ///
+    /// # Arguments
+    /// * `col` - The column of the point.
+    /// * `row` - The row of the point.
+    ///
+    /// # Returns
+    /// The flattened index of the given column and row or `None` if the index is out of bounds.
+    #[inline(always)]
+    #[must_use]
+    pub fn index(&self, col: usize, row: usize) -> Option<usize> {
+        if col < self.cols && row < self.rows {
+            Some(col + row * self.cols)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the point at the given column and row.
+    ///
+    /// # Arguments
+    /// * `col` - The column of the point.
+    /// * `row` - The row of the point.
+    ///
+    /// # Returns
+    /// The point at the given column and row or `None` if the index is out of bounds.
+    #[inline(always)]
+    #[must_use]
+    pub fn get(&self, col: usize, row: usize) -> Option<&Point<T, N>> {
+        self.index(col, row).map(|index| &self.points[index])
+    }
+
+    /// Applies the `action` function to each neighbor of the point at the given column and row.
+    ///
+    /// # Arguments
+    /// * `col` - The column of the point.
+    /// * `row` - The row of the point.
+    ///
+    /// # Returns
+    /// A set of indices of the neighboring points.
+    #[inline]
+    #[must_use]
+    pub fn neighbor_indices(&self, col: usize, row: usize) -> HashSet<usize> {
+        if col >= self.cols || row >= self.rows {
+            return HashSet::new();
+        }
+
+        let mut neighbors = HashSet::with_capacity(8);
+        for i in col.saturating_sub(1)..=(col + 1).min(self.cols - 1) {
+            for j in row.saturating_sub(1)..=(row + 1).min(self.rows - 1) {
+                // Skip the target point itself
+                if i == col && j == row {
+                    continue;
+                }
+
+                if let Some(index) = self.index(i, j) {
+                    neighbors.insert(index);
+                }
+            }
+        }
+        neighbors
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        // Arrange
+        let cols = 16;
+        let rows = 9;
+        let points = vec![[0.0; 3]; cols * rows];
+
+        // Act
+        let actual = MatrixView::new(cols, rows, &points);
+
+        // Assert
+        assert!(actual.is_ok());
+        assert_eq!(
+            actual.unwrap(),
+            MatrixView {
+                cols,
+                rows,
+                points: &points,
+            }
+        );
+    }
+
+    #[rstest]
+    #[case(0, 0)]
+    #[case(0, 9)]
+    #[case(16, 0)]
+    fn test_new_invalid_shape(#[case] cols: usize, #[case] rows: usize) {
+        // Arrange
+        let points = vec![[0.0; 3]; cols * rows];
+
+        // Act
+        let matrix = MatrixView::new(cols, rows, &points);
+
+        // Assert
+        assert!(matrix.is_err());
+        assert_eq!(matrix.unwrap_err(), MatrixError::InvalidShape(cols, rows));
+    }
+
+    #[test]
+    fn test_new_invalid_points() {
+        // Arrange
+        let cols = 16;
+        let rows = 9;
+        let points = vec![[0.0; 3]; cols * rows - 1];
+
+        // Act
+        let matrix = MatrixView::new(cols, rows, &points);
+
+        // Assert
+        assert!(matrix.is_err());
+        assert_eq!(matrix.unwrap_err(), MatrixError::InvalidPoints(cols, rows));
+    }
+
+    #[rstest]
+    #[case(1, 1, 1)]
+    #[case(2, 3, 6)]
+    #[case(16, 9, 144)]
+    fn test_size(#[case] cols: usize, #[case] rows: usize, #[case] expected: usize) {
+        // Arrange
+        let points = vec![[0.0; 3]; cols * rows];
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = matrix.size();
+
+        // Assert
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case(1, 1, (1, 1))]
+    #[case(4, 9, (4, 9))]
+    #[case(9, 4, (9, 4))]
+    #[case(1, 1024, (1, 1024))]
+    #[case(1024, 1, (1024, 1))]
+    fn test_shape(#[case] cols: usize, #[case] rows: usize, #[case] expected: (usize, usize)) {
+        // Arrange
+        let points = vec![[0.0; 3]; cols * rows];
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = matrix.shape();
+
+        // Assert
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case(0, 0, Some(0))]
+    #[case(1, 0, Some(1))]
+    #[case(15, 0, Some(15))]
+    #[case(0, 1, Some(16))]
+    #[case(1, 1, Some(17))]
+    #[case(0, 8, Some(128))]
+    #[case(15, 8, Some(143))]
+    #[case(16, 0, None)]
+    #[case(0, 9, None)]
+    #[case(16, 9, None)]
+    fn test_index(#[case] col: usize, #[case] row: usize, #[case] expected: Option<usize>) {
+        // Arrange
+        let cols = 16;
+        let rows = 9;
+        let points = vec![[0.0; 3]; cols * rows];
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = matrix.index(col, row);
+
+        // Assert
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::center(8, 4, 72)]
+    #[case::left_top(0, 0, 0)]
+    #[case::left_bottom(0, 8, 128)]
+    #[case::right_top(15, 0, 15)]
+    #[case::right_bottom(15, 8, 143)]
+    fn test_get(#[case] col: usize, #[case] row: usize, #[case] index: usize) {
+        // Arrange
+        let cols = 16;
+        let rows = 9;
+        let mut points = vec![[0.0; 3]; cols * rows];
+        for i in 0..points.len() {
+            points[i] = [i as f64, i as f64, i as f64];
+        }
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = matrix.get(col, row);
+
+        // Assert
+        assert!(actual.is_some());
+        assert_eq!(actual.unwrap(), &points[index]);
+    }
+
+    #[rstest]
+    #[case::left_bottom(16, 0)]
+    #[case::right_top(0, 9)]
+    #[case::right_bottom(16, 9)]
+    fn test_get_out_of_bounds(#[case] col: usize, #[case] row: usize) {
+        // Arrange
+        let cols = 16;
+        let rows = 9;
+        let points = vec![[0.0; 3]; cols * rows];
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = matrix.get(col, row);
+
+        // Assert
+        assert!(actual.is_none());
+    }
+
+    #[rstest]
+    #[case((0, 0), vec![1, 16, 17])]
+    #[case((0, 1), vec![0, 1, 17, 32, 33])]
+    #[case((1, 0), vec![0, 2, 16, 17, 18])]
+    #[case((1, 1), vec![0, 1, 2, 16, 18, 32, 33, 34])]
+    #[case((0, 8), vec![112, 113, 129])]
+    #[case((1, 8), vec![112, 113, 114, 128, 130])]
+    #[case((15, 0), vec![14, 30, 31])]
+    #[case((15, 7), vec![110, 111, 126, 142, 143])]
+    #[case((15, 8), vec![126, 127, 142])]
+    fn test_neighbor_indices(#[case] (col, row): (usize, usize), #[case] expected: Vec<usize>) {
+        // Arrange
+        let cols = 16;
+        let rows = 9;
+        let points = vec![[0.0; 3]; cols * rows];
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = matrix.neighbor_indices(col, row);
+
+        // Assert
+        assert_eq!(actual.len(), expected.len());
+        assert_eq!(actual, HashSet::from_iter(expected));
+    }
+
+    #[rstest]
+    #[case::right_top(0, 9)]
+    #[case::left_bottom(16, 0)]
+    #[case::right_bottom(16, 9)]
+    fn test_neighbor_indices_empty(#[case] col: usize, #[case] row: usize) {
+        // Arrange
+        let cols = 16;
+        let rows = 9;
+        let points = vec![[0.0; 3]; cols * rows];
+        let matrix = MatrixView::new(cols, rows, &points).unwrap();
+
+        // Act
+        let actual = matrix.neighbor_indices(col, row);
+
+        // Assert
+        assert!(actual.is_empty());
+    }
+}

--- a/crates/auto-palette/src/math/mod.rs
+++ b/crates/auto-palette/src/math/mod.rs
@@ -1,5 +1,6 @@
 pub mod clustering;
 mod gaussian;
+mod matrix;
 mod metrics;
 mod neighbors;
 mod number;

--- a/crates/auto-palette/src/palette.rs
+++ b/crates/auto-palette/src/palette.rs
@@ -529,6 +529,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use std::str::FromStr;
 
@@ -722,11 +723,11 @@ mod tests {
         // Act
         let image_data = ImageData::load("../../gfx/olympic_logo.png").unwrap();
         let actual: Palette<f64> =
-            Palette::extract_with_algorithm(&image_data, Algorithm::DBSCANpp).unwrap();
+            Palette::extract_with_algorithm(&image_data, Algorithm::SNIC).unwrap();
 
         // Assert
-        assert!(!actual.is_empty());
-        assert!(actual.len() >= 3);
+        assert!(!actual.is_empty(), "Palette should not be empty");
+        assert!(actual.len() >= 6, "Palette should have at least 6 swatches");
     }
 
     #[test]

--- a/crates/auto-palette/tests/palette.rs
+++ b/crates/auto-palette/tests/palette.rs
@@ -46,6 +46,7 @@ fn test_extract_multiple_colors() {
 #[case::dbscan("dbscan")]
 #[case::dbscanpp("dbscan++")]
 #[case::slic("slic")]
+#[case::snic("snic")]
 fn test_builder_with_algorithm(#[case] name: &str) {
     // Arrange
     let image_data = ImageData::load("../../gfx/holly-booth-hLZWGXy5akM-unsplash.jpg").unwrap();

--- a/packages/auto-palette-wasm/test/palette.test.ts
+++ b/packages/auto-palette-wasm/test/palette.test.ts
@@ -150,14 +150,14 @@ describe('@auto-palette/wasm/palette', () => {
     });
 
     it.each([
-      { theme: 'vivid', count: 3, expected: ['#FFD63A', '#4F1C51', '#FF6F61'] },
+      { theme: 'vivid', count: 3, expected: ['#FFD63A', '#FF6F61', '#4F1C51'] },
       { theme: 'muted', count: 3, expected: ['#604652', '#A27B5C', '#3F4F44'] },
-      { theme: 'light', count: 3, expected: ['#6DE1D2', '#FF6F61', '#F7CFD8'] },
-      { theme: 'dark', count: 3, expected: ['#210F37', '#3F4F44', '#604652'] },
+      { theme: 'light', count: 3, expected: ['#F7CFD8', '#FF6F61', '#6DE1D2'] },
+      { theme: 'dark', count: 3, expected: ['#3F4F44', '#210F37', '#604652'] },
       {
         theme: 'colorful',
         count: 3,
-        expected: ['#4F1C51', '#FF6F61', '#6DE1D2'],
+        expected: ['#6DE1D2', '#FF6F61', '#4F1C51'],
       },
     ])(
       'should find the swatches from the palette with $theme theme',
@@ -167,9 +167,8 @@ describe('@auto-palette/wasm/palette', () => {
 
         // Assert
         expect(actual).toHaveLength(3);
-        expect(actual[0].color).toBeSameColor(expected[0]);
-        expect(actual[1].color).toBeSameColor(expected[1]);
-        expect(actual[2].color).toBeSameColor(expected[2]);
+        const actualColors = actual.map((swatch) => swatch.color.toHexString());
+        expect(actualColors).toEqual(expect.arrayContaining(expected));
       },
     );
 


### PR DESCRIPTION
## Description

This pull request introduces the implementation of the SNIC (Simple Non-Iterative Clustering) algorithm for color palette extraction.
The algorithm is based on the following paper:
[Superpixels and Polygons using Simple Non-Iterative Clustering](https://openaccess.thecvf.com/content_cvpr_2017/papers/Achanta_Superpixels_and_Polygons_CVPR_2017_paper.pdf)

## Related Issue

#176 

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
