### PR TITLE
refactor: replace `Matrix::neighbor_indices` with `Matrix::neighbors` returning an iterator

### DIFF
--- a/crates/auto-palette/src/math/clustering/slic.rs
+++ b/crates/auto-palette/src/math/clustering/slic.rs
@@ -143,20 +143,19 @@ where
         let col = index % matrix.cols;
         let row = index / matrix.cols;
 
-        let mut lowest_score = T::max_value();
-        let mut lowest_point = None;
-        matrix
-            .neighbor_indices(col, row)
-            .iter()
-            .for_each(|neighbor_index| {
+        let (_, lowest_point) = matrix.neighbors(col, row).fold(
+            (T::max_value(), None),
+            |(lowest_score, lowest_point), (neighbor_index, neighbor_point)| {
                 let neighbor_col = neighbor_index % matrix.cols;
                 let neighbor_row = neighbor_index / matrix.cols;
                 let score = gradient(matrix, neighbor_col, neighbor_row, self.metric);
                 if score < lowest_score {
-                    lowest_score = score;
-                    lowest_point = matrix.get(neighbor_col, neighbor_row);
+                    (score, Some(neighbor_point))
+                } else {
+                    (lowest_score, lowest_point)
                 }
-            });
+            },
+        );
         lowest_point.copied()
     }
 
@@ -239,6 +238,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use rstest::rstest;
 


### PR DESCRIPTION
## Description

Refactored the `Matrix::neighbor_indices` method by replacing it with `Matrix::neighbors`, which now returns an iterator instead of creating collections like `HashSet` or `Vec`.  
This change improves memory efficiency and enhances flexibility.

## Related Issue
N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
