### PR TITLE
refactor: improve KMeans initialization to use grid-based algorithm instead of Kmeans++ algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,9 @@ arboard            = "3.4.1"
 assert_cmd         = "2.0.14"
 auto-palette       = { version = "0.8.0", path = "crates/auto-palette", default-features = false }
 clap               = { version = "4.5.4", features = ["cargo"] }
-getrandom          = "0.3.1"
 image              = { version = "0.25.1", default-features = false }
 num-traits         = "0.2.18"
 predicates         = "3.1.0"
-rand               = "0.9.0"
-rand_distr         = "0.5.0"
 rstest             = "0.25.0"
 serde              = { version = "1.0.117", features = ["derive"] }
 serde_json         = "1.0.117"

--- a/crates/auto-palette/Cargo.toml
+++ b/crates/auto-palette/Cargo.toml
@@ -18,17 +18,14 @@ rust-version = "1.84.0"
 [features]
 default = ["image"]
 image   = ["dep:image"]
-wasm    = ["getrandom/wasm_js", "dep:serde"]
+wasm    = ["dep:serde"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
 
 [dependencies]
-getrandom  = { workspace = true }
 image      = { workspace = true, optional = true }
 num-traits = { workspace = true }
-rand       = { workspace = true }
-rand_distr = { workspace = true }
 serde      = { workspace = true, optional = true }
 thiserror  = { workspace = true }
 

--- a/crates/auto-palette/src/math/clustering/kmeans.rs
+++ b/crates/auto-palette/src/math/clustering/kmeans.rs
@@ -1,23 +1,29 @@
-use std::{cmp::Ordering, collections::HashSet, fmt::Display};
+use std::fmt::Display;
 
-use rand::{distr::Distribution, Rng};
-use rand_distr::weighted::{AliasableWeight, Error as WeightedAliasIndexError, WeightedAliasIndex};
 use thiserror::Error;
 
 use crate::math::{
-    clustering::{Cluster, ClusteringAlgorithm},
+    clustering::{Cluster, ClusteringAlgorithm, Initializer},
+    matrix::MatrixView,
     metrics::DistanceMetric,
     neighbors::{linear::LinearSearch, search::NeighborSearch},
     point::Point,
     FloatNumber,
 };
 
-/// K-means clustering algorithm error type.
+/// K-means clustering algorithm error types.
+///
+/// # Type Parameters
+/// * `T` - The floating point type.
 #[derive(Debug, PartialEq, Error)]
 pub enum KmeansError<T>
 where
     T: FloatNumber + Display,
 {
+    /// Error when the shape of the points is invalid.
+    #[error("Invalid Shape: The shape of the points must be > 0: {0}x{1}")]
+    InvalidShape(usize, usize),
+
     /// Error when the number of clusters is invalid.
     #[error("Invalid Cluster Count: The number of clusters must be > 0: {0}")]
     InvalidClusterCount(usize),
@@ -30,56 +36,59 @@ where
     #[error("Invalid Tolerance: The tolerance must be > 0: {0}")]
     InvalidTolerance(T),
 
-    /// Error when the distance metric is invalid.
-    #[error("Weighted Alias Index Error: {0}")]
-    WeightedAliasIndexError(#[from] WeightedAliasIndexError),
-
     /// Error when the points is empty.
     #[error("Empty Points: The points must be non-empty.")]
     EmptyPoints,
+
+    /// Error when the points are not in the same shape.
+    #[error("Invalid Points: The points must be in the same shape: {0}x{1}")]
+    InvalidPoints(usize, usize),
 }
 
 /// K-means clustering algorithm.
 ///
+/// This implementation leverages an evenly-spaced grid to pick the initial centroids.
+/// For image pixel data this tends to stabilise the result and speeds-up convergence.
+///
 /// # Type Parameters
 /// * `T` - The floating point type.
-/// * `R` - The random number generator.
-#[derive(Debug)]
-pub struct KMeans<T, R>
+#[derive(Debug, PartialEq)]
+pub struct KMeans<T>
 where
     T: FloatNumber,
-    R: Rng + Clone,
 {
+    shape: (usize, usize),
     k: usize,
     max_iter: usize,
     tolerance: T,
     metric: DistanceMetric,
-    rng: R,
 }
 
-impl<T, R> KMeans<T, R>
+impl<T> KMeans<T>
 where
     T: FloatNumber,
-    R: Rng + Clone,
 {
     /// Creates a new `Kmeans` instance.
     ///
     /// # Arguments
+    /// * `shape` - The shape of the points.
     /// * `k` - The number of clusters.
     /// * `max_iter` - The maximum number of iterations.
     /// * `tolerance` - The tolerance for convergence conditions.
     /// * `metric` - The distance metric to use.
-    /// * `strategy` - The initialization strategy to use.
     ///
     /// # Returns
     /// A new `Kmeans` instance.
     pub fn new(
+        shape: (usize, usize),
         k: usize,
         max_iter: usize,
         tolerance: T,
         metric: DistanceMetric,
-        rng: R,
     ) -> Result<Self, KmeansError<T>> {
+        if shape.0 == 0 || shape.1 == 0 {
+            return Err(KmeansError::InvalidShape(shape.0, shape.1));
+        }
         if k == 0 {
             return Err(KmeansError::InvalidClusterCount(k));
         }
@@ -90,56 +99,37 @@ where
             return Err(KmeansError::InvalidTolerance(tolerance));
         }
         Ok(Self {
+            shape,
             k,
             max_iter,
             tolerance,
             metric,
-            rng,
         })
     }
 
+    /// Initializes the centroids for clustering.
+    ///
+    /// # Type Parameters
+    /// * `N` - The number of dimensions.
+    ///
+    /// # Arguments
+    /// * `points` - The points to cluster.
+    ///
+    /// # Returns
+    /// A vector of centroids for clustering.
     fn initialize<const N: usize>(
         &self,
         points: &[Point<T, N>],
-        k: usize,
-    ) -> Result<Vec<Point<T, N>>, KmeansError<T>>
-    where
-        T: FloatNumber + AliasableWeight,
-        R: Rng,
-    {
-        let mut selected = HashSet::with_capacity(k);
-        let mut centroids = Vec::with_capacity(k);
-        let mut rng = self.rng.clone();
+    ) -> Result<Vec<Point<T, N>>, KmeansError<T>> {
+        let (cols, rows) = self.shape;
+        let matrix = MatrixView::new(cols, rows, points)
+            .map_err(|_| KmeansError::InvalidPoints(cols, rows))?;
 
-        // 1. Randomly select the first centroid from the data points.
-        let index = rng.random_range(0..points.len());
-        selected.insert(index);
-        centroids.push(points[index]);
-
-        // 2. For each remaining centroid, select the point with the maximum distance from the existing centroids.
-        while centroids.len() < k {
-            let distances: Vec<T> = points
-                .iter()
-                .enumerate()
-                .map(|(index, point)| {
-                    if selected.contains(&index) {
-                        T::zero()
-                    } else {
-                        centroids
-                            .iter()
-                            .map(|centroid| self.metric.measure(centroid, point))
-                            .min_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal))
-                            .unwrap_or(T::epsilon()) // Use an epsilon value to avoid zero distance
-                    }
-                })
-                .collect();
-
-            let weighted_index =
-                WeightedAliasIndex::new(distances).map_err(KmeansError::WeightedAliasIndexError)?;
-            let index = weighted_index.sample(&mut rng);
-            selected.insert(index);
-            centroids.push(points[index]);
-        }
+        let centroids = Initializer::Grid
+            .initialize(&matrix, self.k)
+            .into_iter()
+            .map(|index| points[index])
+            .collect();
         Ok(centroids)
     }
 
@@ -159,23 +149,21 @@ where
             }
         }
 
-        let new_centroids: Vec<Point<T, N>> =
-            clusters.iter().map(|cluster| *cluster.centroid()).collect();
-
-        let converged = centroids
-            .iter()
-            .zip(&new_centroids)
-            .all(|(old, new)| self.metric.measure(old, new) <= self.tolerance);
-
-        centroids.copy_from_slice(&new_centroids);
-        converged
+        centroids
+            .iter_mut()
+            .zip(clusters)
+            .fold(true, |converged, (old_centroid, cluster)| {
+                let new_centroid = cluster.centroid();
+                let distance = self.metric.measure(old_centroid, new_centroid);
+                *old_centroid = *new_centroid;
+                converged && distance <= self.tolerance
+            })
     }
 }
 
-impl<T, const N: usize, R> ClusteringAlgorithm<T, N> for KMeans<T, R>
+impl<T, const N: usize> ClusteringAlgorithm<T, N> for KMeans<T>
 where
-    T: FloatNumber + AliasableWeight,
-    R: Rng + Clone,
+    T: FloatNumber,
 {
     type Err = KmeansError<T>;
 
@@ -197,11 +185,10 @@ where
             return Ok(clusters);
         }
 
-        let mut centroids = self.initialize(points, self.k)?;
-        let mut clusters = vec![Cluster::new(); self.k];
+        let mut centroids = self.initialize(points)?;
+        let mut clusters = vec![Cluster::new(); centroids.len()];
         for _ in 0..self.max_iter {
-            let converged = self.iterate(points, &mut centroids, &mut clusters);
-            if converged {
+            if self.iterate(points, &mut centroids, &mut clusters) {
                 break;
             }
         }
@@ -211,7 +198,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use rand::{rng, rngs::ThreadRng};
     use rstest::rstest;
 
     use super::*;
@@ -220,17 +206,40 @@ mod tests {
     fn test_new() {
         // Act
         let metric = DistanceMetric::Euclidean;
-        let actual: KMeans<f32, ThreadRng> = KMeans::new(3, 10, 1e-3, metric, rng()).unwrap();
+        let actual: KMeans<f64> = KMeans::new((192, 128), 3, 10, 1e-3, metric).unwrap();
 
         // Assert
-        assert_eq!(actual.k, 3);
-        assert_eq!(actual.max_iter, 10);
-        assert_eq!(actual.tolerance, 1e-3);
-        assert_eq!(actual.metric, DistanceMetric::Euclidean);
+        assert_eq!(
+            actual,
+            KMeans {
+                shape: (192, 128),
+                k: 3,
+                max_iter: 10,
+                tolerance: 1e-3,
+                metric: DistanceMetric::Euclidean,
+            }
+        );
     }
 
     #[rstest]
+    #[case::invalid_shape_cols(
+    (0, 128),
+        3,
+        10,
+        1e-3,
+        DistanceMetric::Euclidean,
+        KmeansError::InvalidShape(0, 128)
+    )]
+    #[case::invalid_shape_rows(
+    (192, 0),
+        3,
+        10,
+        1e-3,
+        DistanceMetric::Euclidean,
+        KmeansError::InvalidShape(192, 0)
+    )]
     #[case::invalid_clusters(
+    (192, 128),
         0,
         10,
         1e-3,
@@ -238,6 +247,7 @@ mod tests {
         KmeansError::InvalidClusterCount(0)
     )]
     #[case::invalid_iterations(
+    (192, 128),
         3,
         0,
         1e-3,
@@ -245,6 +255,7 @@ mod tests {
         KmeansError::InvalidIterations(0)
     )]
     #[case::invalid_tolerance(
+    (192, 128),
         3,
         10,
         0.0,
@@ -252,6 +263,7 @@ mod tests {
         KmeansError::InvalidTolerance(0.0)
     )]
     fn test_new_error(
+        #[case] shape: (usize, usize),
         #[case] k: usize,
         #[case] max_iter: usize,
         #[case] tolerance: f32,
@@ -259,7 +271,7 @@ mod tests {
         #[case] expected: KmeansError<f32>,
     ) {
         // Act
-        let actual = KMeans::new(k, max_iter, tolerance, metric, rng());
+        let actual = KMeans::new(shape, k, max_iter, tolerance, metric);
 
         // Assert
         assert!(actual.is_err());
@@ -269,32 +281,31 @@ mod tests {
     #[test]
     fn test_fit() {
         // Arrange
+        let cols = 16;
+        let rows = 9;
         let metric = DistanceMetric::Euclidean;
-        let kmeans: KMeans<f32, ThreadRng> = KMeans::new(3, 10, 1e-3, metric, rng()).unwrap();
+        let kmeans: KMeans<f64> = KMeans::new((cols, rows), 6, 10, 1e-3, metric).unwrap();
+
+        let mut points = vec![[0.0; 3]; cols * rows];
+        for i in 0..cols {
+            for j in 0..rows {
+                points[i * rows + j] = [i as f64, j as f64, 0.0];
+            }
+        }
 
         // Act
-        let points = [
-            [0.0, 0.0, 0.0],
-            [0.0, 0.0, 1.0],
-            [1.0, 0.0, 0.0],
-            [2.0, 2.0, 2.0],
-            [2.0, 1.0, 2.0],
-            [4.0, 4.0, 4.0],
-            [4.0, 4.0, 5.0],
-            [3.0, 4.0, 5.0],
-        ];
         let actual = kmeans.fit(&points);
 
         // Assert
         assert!(actual.is_ok());
-        assert_eq!(actual.unwrap().len(), 3);
+        assert_eq!(actual.unwrap().len(), 6);
     }
 
     #[test]
     fn test_fit_single_cluster() {
         // Arrange
         let metric = DistanceMetric::Euclidean;
-        let kmeans = KMeans::new(3, 10, 1e-3, metric, rng()).unwrap();
+        let kmeans = KMeans::new((3, 1), 3, 10, 1e-3, metric).unwrap();
 
         // Act
         let points = [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]];
@@ -306,17 +317,32 @@ mod tests {
     }
 
     #[test]
-    fn test_fit_empty() {
+    fn test_fit_empty_points() {
         // Arrange
         let metric = DistanceMetric::Euclidean;
-        let kmeans: KMeans<f32, ThreadRng> = KMeans::new(3, 10, 1e-3, metric, rng()).unwrap();
+        let kmeans: KMeans<f64> = KMeans::new((16, 9), 3, 10, 1e-3, metric).unwrap();
 
         // Act
-        let points: Vec<Point<f32, 2>> = Vec::new();
+        let points: Vec<Point<f64, 2>> = Vec::new();
         let actual = kmeans.fit(&points);
 
         // Assert
         assert!(actual.is_err());
         assert_eq!(actual.unwrap_err(), KmeansError::EmptyPoints);
+    }
+
+    #[test]
+    fn test_fit_invalid_points() {
+        // Arrange
+        let metric = DistanceMetric::Euclidean;
+        let kmeans: KMeans<f64> = KMeans::new((16, 9), 3, 10, 1e-3, metric).unwrap();
+
+        // Act
+        let points: Vec<Point<f64, 2>> = vec![[0.0; 2]; 16 * 8];
+        let actual = kmeans.fit(&points);
+
+        // Assert
+        assert!(actual.is_err());
+        assert_eq!(actual.unwrap_err(), KmeansError::InvalidPoints(16, 9));
     }
 }

--- a/crates/auto-palette/src/palette.rs
+++ b/crates/auto-palette/src/palette.rs
@@ -1,7 +1,5 @@
 use std::{cmp::Reverse, marker::PhantomData};
 
-use rand_distr::weighted::AliasableWeight;
-
 use crate::{
     algorithm::Algorithm,
     color::{rgb_to_xyz, xyz_to_lab, Color, Lab, D65},
@@ -46,14 +44,14 @@ use crate::{
 #[derive(Debug, Clone, PartialEq)]
 pub struct Palette<T>
 where
-    T: FloatNumber + AliasableWeight,
+    T: FloatNumber,
 {
     swatches: Vec<Swatch<T>>,
 }
 
 impl<T> Palette<T>
 where
-    T: FloatNumber + AliasableWeight,
+    T: FloatNumber,
 {
     /// Creates a new `Palette` instance.
     ///
@@ -249,7 +247,7 @@ type DynFilterFn = Box<dyn Fn(&Pixel) -> bool + Send + Sync + 'static>;
 /// ```
 pub struct PaletteBuilder<T>
 where
-    T: FloatNumber + AliasableWeight,
+    T: FloatNumber,
 {
     algorithm: Algorithm,
     filters: Vec<DynFilterFn>,
@@ -259,7 +257,7 @@ where
 
 impl<T> PaletteBuilder<T>
 where
-    T: FloatNumber + AliasableWeight,
+    T: FloatNumber,
 {
     /// The default maximum number of swatches to extract.
     const DEFAULT_MAX_SWATCHES: usize = 256;
@@ -384,7 +382,7 @@ fn to_feature_points<T>(
     filters: &[DynFilterFn],
 ) -> Vec<Point<T, 5>>
 where
-    T: FloatNumber + AliasableWeight,
+    T: FloatNumber,
 {
     let width_f = T::from_usize(width);
     let height_f = T::from_usize(height);


### PR DESCRIPTION
## Description

Refactored the KMeans initialization process to use grid-based centroids instead of the KMeans++ algorithm.  
This change improves clustering stability and performance.  
Additionally, memory efficiency was enhanced by avoiding unnecessary collection allocations.


## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
