### PR TITLE
ci: update Fossa and CodSpeed triggers to run on main branch merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - 'main'
   pull_request:
-    branches: [ main ]
+    branches:
+      - 'main'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codsspeed.yml
+++ b/.github/workflows/codsspeed.yml
@@ -3,8 +3,7 @@ name: CodSpeed
 on:
   push:
     branches:
-      - "main"
-  pull_request:
+      - 'main'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,6 +1,9 @@
 name: FOSSA
 
 on:
+  push:
+    branches:
+    - 'main'
   schedule:
     - cron: '0 0 * * *' # At the end of every day
   workflow_dispatch:


### PR DESCRIPTION
## Description

Updated GitHub Actions workflows to modify the triggers for FOSSA and CodSpeed.  
Both workflows are now configured to run only when changes are merged into the `main` branch, ensuring consistency across CI processes.

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
