### PR TITLE
fix: support building auto-palette on Rust stable versions, addressing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Deprecated
 ### Removed 
 ### Fixed
+- Ensure compatibility with Rust stable versions by removing unstable `#![feature]` attributes. (#184)
+
 ### Security
 
 ## [v0.8.0](https://github.com/t28hub/auto-palette/compare/v0.7.0...v0.8.0) - 2025-04-28

--- a/crates/auto-palette-cli/Cargo.toml
+++ b/crates/auto-palette-cli/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 
 # `cargo msrv` does not support `rust-version.workspace` yet.
 # https://github.com/foresterre/cargo-msrv/issues/590
-rust-version = "1.84.0"
+rust-version = "1.86.0"
 
 [dependencies]
 anyhow       = { workspace = true }

--- a/crates/auto-palette-wasm/Cargo.toml
+++ b/crates/auto-palette-wasm/Cargo.toml
@@ -12,9 +12,8 @@ license.workspace    = true
 homepage.workspace   = true
 repository.workspace = true
 
-# `cargo msrv` does not support `rust-version.workspace` yet.
 # https://github.com/foresterre/cargo-msrv/issues/590
-rust-version = "1.84.0"
+rust-version = "1.86.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/auto-palette/Cargo.toml
+++ b/crates/auto-palette/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 
 # `cargo msrv` does not support `rust-version.workspace` yet
 # https://github.com/foresterre/cargo-msrv/issues/590
-rust-version = "1.84.0"
+rust-version = "1.86.0"
 
 [features]
 default = ["image"]

--- a/crates/auto-palette/src/algorithm.rs
+++ b/crates/auto-palette/src/algorithm.rs
@@ -224,7 +224,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use rstest::rstest;
 

--- a/crates/auto-palette/src/assert.rs
+++ b/crates/auto-palette/src/assert.rs
@@ -48,7 +48,6 @@ macro_rules! assert_approx_eq {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage, coverage(off))]
 mod test {
     #[test]
     fn test_assert_approx_eq() {

--- a/crates/auto-palette/src/lib.rs
+++ b/crates/auto-palette/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(array_chunks, coverage_attribute)]
-
 mod algorithm;
 mod assert;
 pub mod color;

--- a/crates/auto-palette/src/math/clustering/slic.rs
+++ b/crates/auto-palette/src/math/clustering/slic.rs
@@ -238,7 +238,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use rstest::rstest;
 

--- a/crates/auto-palette/src/math/clustering/snic.rs
+++ b/crates/auto-palette/src/math/clustering/snic.rs
@@ -261,7 +261,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use rstest::rstest;
 

--- a/crates/auto-palette/src/math/matrix.rs
+++ b/crates/auto-palette/src/math/matrix.rs
@@ -221,7 +221,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use rstest::rstest;
 

--- a/crates/auto-palette/src/math/sampling/diversity.rs
+++ b/crates/auto-palette/src/math/sampling/diversity.rs
@@ -237,7 +237,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use rstest::rstest;
 

--- a/crates/auto-palette/src/math/sampling/farthest.rs
+++ b/crates/auto-palette/src/math/sampling/farthest.rs
@@ -140,7 +140,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use rstest::rstest;
 

--- a/crates/auto-palette/src/math/sampling/weighted_farthest.rs
+++ b/crates/auto-palette/src/math/sampling/weighted_farthest.rs
@@ -143,7 +143,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use rstest::rstest;
 

--- a/crates/auto-palette/src/palette.rs
+++ b/crates/auto-palette/src/palette.rs
@@ -386,14 +386,18 @@ where
 {
     let width_f = T::from_usize(width);
     let height_f = T::from_usize(height);
-    data.array_chunks::<PIXEL_SIZE>()
+    data.chunks_exact(PIXEL_SIZE)
         .enumerate()
         .filter_map(|(index, chunk)| {
-            if filters.iter().any(|filter| filter(chunk)) {
+            let r = chunk[0];
+            let g = chunk[1];
+            let b = chunk[2];
+            let a = chunk[3];
+            if filters.iter().any(|filter| filter(&[r, g, b, a])) {
                 return None;
             }
 
-            let (x, y, z) = rgb_to_xyz::<T>(chunk[0], chunk[1], chunk[2]);
+            let (x, y, z) = rgb_to_xyz::<T>(r, g, b);
             let (l, a, b) = xyz_to_lab::<T, D65>(x, y, z);
             let x = T::from_usize(index % width);
             let y = T::from_usize(index / width);
@@ -527,7 +531,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use std::str::FromStr;
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "lint-staged": {
     "*.{js,ts,json}": ["biome format --write"],
     "*.toml": ["taplo format"],
-    "*.rs": ["cargo fmt --all --"]
+    "*.rs": ["cargo +nightly fmt --all --"]
   },
   "engines": {
     "node": ">=18.0.0",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "nightly-2025-01-23"
+channel    = "stable"
 profile    = "minimal"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Description

This pull request resolves the build failure of the `auto-palette` crate on Rust stable versions.  
The changes ensure compatibility with the stable toolchain by removing unstable `#![feature]` attributes.


## Related Issue
#184 

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
