### PR TITLE
test: add SLIC and SNIC to benchmark tests

### DIFF
--- a/crates/auto-palette/benches/algorithm.rs
+++ b/crates/auto-palette/benches/algorithm.rs
@@ -9,7 +9,7 @@ fn main() {
 
 const IMAGE_PATH: &str = "../../gfx/laura-clugston-pwW2iV9TZao-unsplash.jpg";
 
-const ALGORITHMS: &[&str] = &["kmeans", "dbscan", "dbscan++"];
+const ALGORITHMS: &[&str] = &["kmeans", "dbscan", "dbscan++", "slic", "snic"];
 
 #[divan::bench(types = [f32, f64], args = ALGORITHMS, sample_count = 10)]
 fn bench_algorithm<T>(bencher: Bencher, name: &str)


### PR DESCRIPTION
## Description
This pull request adds `SLIC` and `SNIC` algorithms to the benchmark tests for the `auto-palette` crate. 

## Related Issue
#176 
#177 

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other: Testing

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
