### PR TITLE
feat: add support for SLIC and SNIC algorithm to CLI tool

### DIFF
--- a/crates/auto-palette-cli/Cargo.toml
+++ b/crates/auto-palette-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                 = "auto-palette-cli"
-description          = "🎨 A CLI tool to extract prominent color palettes from images."
+description          = "🎨 CLI tool to extract a prominent color palette from an image."
 readme               = "./README.md"
 categories           = ["graphics", "algorithms", "multimedia::images", "command-line-utilities"]
 keywords             = ["palette", "color", "image", "color-palette", "color-extraction"]

--- a/crates/auto-palette-cli/src/main.rs
+++ b/crates/auto-palette-cli/src/main.rs
@@ -89,7 +89,11 @@ fn main() -> anyhow::Result<()> {
                 context.args().theme
             )
         })?;
-    context.args().output.print(&context, &swatches).unwrap();
+    context
+        .args()
+        .output_format
+        .print(&context, &swatches)
+        .unwrap();
 
     println!(
         "Extracted {} swatch(es) in {}.{:03} seconds",

--- a/crates/auto-palette-cli/src/output/json.rs
+++ b/crates/auto-palette-cli/src/output/json.rs
@@ -38,7 +38,7 @@ impl<'a> JsonPrinter<'a> {
     {
         let mut swatch_map = Map::with_capacity(3);
 
-        let color_format = self.context.args().color;
+        let color_format = self.context.args().color_space;
         let color = color_format.fmt(swatch.color());
         swatch_map.insert(KEY_COLOR.into(), Value::String(color));
 

--- a/crates/auto-palette-cli/src/output/table.rs
+++ b/crates/auto-palette-cli/src/output/table.rs
@@ -35,7 +35,7 @@ impl Printer for TablePrinter<'_> {
     {
         let mut writer = BufWriter::new(output);
 
-        let color_format = self.context.args().color;
+        let color_format = self.context.args().color_space;
         let initial_widths = [
             HEADINGS[0].len(),
             HEADINGS[1].len(),

--- a/crates/auto-palette-cli/src/output/text.rs
+++ b/crates/auto-palette-cli/src/output/text.rs
@@ -38,7 +38,7 @@ impl<'a> TextPrinter<'a> {
             format!("{} ", styled)
         };
 
-        let color_format = self.context.args().color;
+        let color_format = self.context.args().color_space;
         let color = color_format.fmt(swatch.color());
         let color_str = format!("{:<width$}", color, width = widths[0]);
 
@@ -90,7 +90,7 @@ impl Printer for TextPrinter<'_> {
     {
         let mut writer = BufWriter::new(output);
 
-        let color_format = self.context.args().color;
+        let color_format = self.context.args().color_space;
         let widths = swatches.iter().fold([0, 0, 0], |acc, swatch| {
             let color_width = color_format.fmt(swatch.color()).len();
 

--- a/crates/auto-palette-cli/tests/cli.rs
+++ b/crates/auto-palette-cli/tests/cli.rs
@@ -4,6 +4,7 @@ use arboard::Clipboard;
 use assert_cmd::Command;
 use image::io::Reader as ImageReader;
 use predicates::prelude::*;
+use rstest::rstest;
 
 /// Returns the auto-palette command.
 ///
@@ -22,7 +23,7 @@ fn test_cli() {
         .arg("dbscan")
         .arg("--count")
         .arg("6")
-        .arg("--output")
+        .arg("--output-format")
         .arg("table")
         .arg("--no-resize")
         .assert()
@@ -82,7 +83,7 @@ fn test_using_clipboard_as_input() {
 #[test]
 fn test_missing_input() {
     let assert = auto_palette().assert().stderr(predicate::str::contains(
-        "🎨 A CLI tool to extract prominent color palettes from images.",
+        "🎨 CLI tool to extract a prominent color palette from an image.",
     ));
     assert.failure();
 }
@@ -110,12 +111,17 @@ fn test_multiple_inputs() {
     assert.failure();
 }
 
-#[test]
-fn test_algorithm() {
+#[rstest]
+#[case::dbscan("dbscan")]
+#[case::dbscanpp("dbscan++")]
+#[case::kmeans("kmeans")]
+#[case::slic("slic")]
+#[case::snic("snic")]
+fn test_algorithm(#[case] algorithm: &str) {
     let assert = auto_palette()
         .arg("../../gfx/olympic_logo.png")
         .arg("--algorithm")
-        .arg("kmeans")
+        .arg(algorithm)
         .assert();
     assert.success();
 }
@@ -128,7 +134,7 @@ fn test_invalid_algorithm() {
         .arg("unknown")
         .assert()
         .stderr(predicate::str::contains(
-            "invalid value 'unknown' for '--algorithm <name>'",
+            "invalid value 'unknown' for '--algorithm <ALGORITHM>'",
         ));
     assert.failure();
 }
@@ -151,7 +157,7 @@ fn test_invalid_theme() {
         .arg("unknown")
         .assert()
         .stderr(predicate::str::contains(
-            "invalid value 'unknown' for '--theme <name>'",
+            "invalid value 'unknown' for '--theme <THEME>'",
         ));
     assert.failure();
 }
@@ -170,14 +176,37 @@ fn test_invalid_count() {
 }
 
 #[test]
-fn test_invalid_output() {
+fn test_color_space() {
     let assert = auto_palette()
         .arg("../../gfx/olympic_logo.png")
-        .arg("--output")
+        .arg("--color-space")
+        .arg("rgb")
+        .assert();
+    assert.success();
+}
+
+#[test]
+fn test_invalid_color_space() {
+    let assert = auto_palette()
+        .arg("../../gfx/olympic_logo.png")
+        .arg("--color-space")
         .arg("unknown")
         .assert()
         .stderr(predicate::str::contains(
-            "invalid value 'unknown' for '--output <name>'",
+            "invalid value 'unknown' for '--color-space <SPACE>'",
+        ));
+    assert.failure();
+}
+
+#[test]
+fn test_invalid_output_format() {
+    let assert = auto_palette()
+        .arg("../../gfx/olympic_logo.png")
+        .arg("--output-format")
+        .arg("unknown")
+        .assert()
+        .stderr(predicate::str::contains(
+            "invalid value 'unknown' for '--output-format <FORMAT>'",
         ));
     assert.failure();
 }

--- a/crates/auto-palette/src/palette.rs
+++ b/crates/auto-palette/src/palette.rs
@@ -548,9 +548,11 @@ mod tests {
 
     #[cfg(feature = "image")]
     #[rstest]
-    #[case::kmeans("kmeans")]
     #[case::dbscan("dbscan")]
     #[case::dbscanpp("dbscan++")]
+    #[case::kmeans("kmeans")]
+    #[case::slic("slic")]
+    #[case::snic("snic")]
     fn test_builder_with_algorithm(#[case] name: &str) {
         // Act
         let image_data = ImageData::load("../../gfx/olympic_logo.png").unwrap();

--- a/crates/auto-palette/tests/palette.rs
+++ b/crates/auto-palette/tests/palette.rs
@@ -71,9 +71,9 @@ fn test_extract_multiple_colors() {
 }
 
 #[rstest]
-#[case::kmeans("kmeans")]
 #[case::dbscan("dbscan")]
 #[case::dbscanpp("dbscan++")]
+#[case::kmeans("kmeans")]
 #[case::slic("slic")]
 #[case::snic("snic")]
 fn test_builder_with_algorithm(#[case] name: &str) {


### PR DESCRIPTION
## Description

This Pull Request added support for `SLIC` and `SNIC` algorithms to the CLI tool.  
These algorithms provide faster and more efficient color palette extraction for large images.  
Additionally, updated the `--help` message to include descriptions for `SLIC` and `SNIC`, making the CLI tool more  informative.

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
