### PR TITLE
feat: add SLIC and SNIC algorithm support to auto-palette-wasm

### DIFF
--- a/crates/auto-palette-wasm/src/types.rs
+++ b/crates/auto-palette-wasm/src/types.rs
@@ -10,7 +10,7 @@ const TYPE_DEFINITION: &'static str = r#"
 /**
  * The algorithm of the palette.
  */
-export type Algorithm = "dbscan" | "dbscan++" | "kmeans";
+export type Algorithm = "dbscan" | "dbscan++" | "kmeans" | "slic" | "snic";
 
 /**
  * The theme of the palette.

--- a/packages/auto-palette-wasm/test/palette.bench.ts
+++ b/packages/auto-palette-wasm/test/palette.bench.ts
@@ -52,6 +52,34 @@ describe('benchmark @auto-palette/wasm vs auto-palette-ts', () => {
     expect(swatches).toHaveLength(6);
   });
 
+  bench('extract with SLIC algorithm in WebAssembly', async () => {
+    // Arrange
+    const imageData = await loadImageData(IMAGE_PATH);
+
+    // Act
+    const palette = AutoPaletteWasm.Palette.extract(imageData, 'slic');
+    const swatches = palette.findSwatches(6);
+
+    // Assert
+    expect(palette.isEmpty()).toBeFalsy();
+    expect(palette.length).toBeGreaterThan(32);
+    expect(swatches).toHaveLength(6);
+  });
+
+  bench('extract with SNIC algorithm in WebAssembly', async () => {
+    // Arrange
+    const imageData = await loadImageData(IMAGE_PATH);
+
+    // Act
+    const palette = AutoPaletteWasm.Palette.extract(imageData, 'snic');
+    const swatches = palette.findSwatches(6);
+
+    // Assert
+    expect(palette.isEmpty()).toBeFalsy();
+    expect(palette.length).toBeGreaterThan(32);
+    expect(swatches).toHaveLength(6);
+  });
+
   bench('extract with DBSCAN algorithm in TypeScript', async () => {
     // Arrange
     const imageData = await loadImageData(IMAGE_PATH);

--- a/packages/auto-palette-wasm/test/palette.browser.e2e.ts
+++ b/packages/auto-palette-wasm/test/palette.browser.e2e.ts
@@ -144,6 +144,8 @@ describe('@auto-palette/wasm', () => {
         { algorithm: 'dbscan', expectedLength: 48 },
         { algorithm: 'dbscan++', expectedLength: 72 },
         { algorithm: 'kmeans', expectedLength: 24 },
+        { algorithm: 'slic', expectedLength: 32 },
+        { algorithm: 'snic', expectedLength: 32 },
       ])(
         'should extract the palette from an image with the $algorithm algorithm',
         ({ algorithm, expectedLength }) => {

--- a/packages/auto-palette-wasm/test/palette.node.e2e.ts
+++ b/packages/auto-palette-wasm/test/palette.node.e2e.ts
@@ -61,6 +61,8 @@ describe('@auto-palette/wasm', () => {
         { algorithm: 'dbscan', expectedLength: 48 },
         { algorithm: 'dbscan++', expectedLength: 72 },
         { algorithm: 'kmeans', expectedLength: 24 },
+        { algorithm: 'slic', expectedLength: 64 },
+        { algorithm: 'snic', expectedLength: 64 },
       ])(
         'should extract the palette from an image with the $algorithm algorithm',
         ({ algorithm, expectedLength }) => {
@@ -89,36 +91,36 @@ describe('@auto-palette/wasm', () => {
 
         // Assert
         expect(swatches).toHaveLength(3);
-        expect(swatches[0].color).toBeSimilarColor('#5ECBFE');
-        expect(swatches[1].color).toBeSimilarColor('#C7101E');
-        expect(swatches[2].color).toBeSimilarColor('#CFC663');
+        expect(swatches[0].color).toBeSimilarColor('#89DAFE');
+        expect(swatches[1].color).toBeSimilarColor('#BF010D');
+        expect(swatches[2].color).toBeSimilarColor('#FCDC24');
       });
 
       it.skipIf(isLinux).each([
         {
           count: 3,
           theme: 'colorful',
-          expected: ['#01B1FC', '#A48611', '#C72C52'],
+          expected: ['#0866A7', '#A28713', '#CE3A54'],
         },
         {
           count: 3,
           theme: 'vivid',
-          expected: ['#01B1FC', '#A48611', '#D6314D'],
+          expected: ['#711978', '#B99813', '#E83748'],
         },
         {
           count: 3,
           theme: 'muted',
-          expected: ['#04524E', '#846E15', '#CD85B7'],
+          expected: ['#02457A', '#03686A', '#55061A'],
         },
         {
           count: 3,
           theme: 'light',
-          expected: ['#5ECBFE', '#CD85B7', '#CFC663'],
+          expected: ['#5DBFF7', '#CDC26F', '#E96894'],
         },
         {
           count: 3,
           theme: 'dark',
-          expected: ['#032F55', '#053E2D', '#4A0117'],
+          expected: ['#013764', '#023D33', '#55061A'],
         },
       ])(
         'should find the swatches from the palette with the $theme theme',

--- a/packages/auto-palette-wasm/test/palette.test.ts
+++ b/packages/auto-palette-wasm/test/palette.test.ts
@@ -222,6 +222,8 @@ describe('@auto-palette/wasm/palette', () => {
         { algorithm: 'dbscan' },
         { algorithm: 'dbscan++' },
         { algorithm: 'kmeans' },
+        { algorithm: 'slic' },
+        { algorithm: 'snic' },
       ])(
         'should extract a palette from an image with the $algorithm algorithm',
         ({ algorithm }) => {


### PR DESCRIPTION
## Description

This Pull Request added support for SLIC and SNIC algorithms to the `auto-palette-wasm` module.  
These algorithms enhance the palette extraction process by providing more efficient and accurate segmentation for image processing. 

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
