### PR TITLE
perf: replace `HashMap` and `HashSet` with `FxHashMap` and `FxHashSet`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ image              = { version = "0.25.1", default-features = false }
 num-traits         = "0.2.18"
 predicates         = "3.1.0"
 rstest             = "0.25.0"
+rustc-hash         = "2.1.1"
 serde              = { version = "1.0.117", features = ["derive"] }
 serde_json         = "1.0.117"
 serde_test         = "1.0.117"

--- a/crates/auto-palette/Cargo.toml
+++ b/crates/auto-palette/Cargo.toml
@@ -26,6 +26,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)
 [dependencies]
 image      = { workspace = true, optional = true }
 num-traits = { workspace = true }
+rustc-hash = { workspace = true }
 serde      = { workspace = true, optional = true }
 thiserror  = { workspace = true }
 

--- a/crates/auto-palette/src/image/segmentation/dbscan/algorithm.rs
+++ b/crates/auto-palette/src/image/segmentation/dbscan/algorithm.rs
@@ -1,4 +1,6 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
+
+use rustc_hash::FxHashMap;
 
 use crate::{
     image::{
@@ -70,7 +72,7 @@ where
         let center_search = KdTreeSearch::build(&centers, self.metric, Self::MAX_LEAF_SIZE);
 
         // Merge small segments into their nearest large segment
-        let relocation_table: HashMap<_, _> = builder
+        let relocation_table: FxHashMap<_, _> = builder
             .iter()
             .filter(|s| s.len() < min_size)
             .filter_map(|s| {

--- a/crates/auto-palette/src/image/segmentation/label.rs
+++ b/crates/auto-palette/src/image/segmentation/label.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::{image::segmentation::segment::SegmentMetadata, math::FloatNumber};
 
@@ -18,7 +18,7 @@ where
     height: usize,
 
     /// The segments in the label image, indexed by their labels.
-    segments: HashMap<usize, SegmentMetadata<T>>,
+    segments: FxHashMap<usize, SegmentMetadata<T>>,
 }
 
 impl<T> LabelImage<T>
@@ -116,7 +116,7 @@ where
     height: usize,
 
     /// The segments in the label image, indexed by their labels.
-    segments: HashMap<usize, SegmentMetadata<T>>,
+    segments: FxHashMap<usize, SegmentMetadata<T>>,
 }
 
 impl<T> Builder<T>
@@ -136,7 +136,7 @@ where
         Self {
             width,
             height,
-            segments: HashMap::new(),
+            segments: FxHashMap::default(),
         }
     }
 
@@ -253,6 +253,8 @@ where
 mod tests {
     use std::collections::HashSet;
 
+    use rustc_hash::FxHashSet;
+
     use super::*;
     use crate::image::LABXY_CHANNELS;
 
@@ -267,7 +269,7 @@ mod tests {
             Builder {
                 width: 480,
                 height: 320,
-                segments: HashMap::new(),
+                segments: FxHashMap::default(),
             }
         );
     }
@@ -528,7 +530,7 @@ mod tests {
             SegmentMetadata {
                 label,
                 center: [1.0; LABXY_CHANNELS],
-                indices: HashSet::from([0]),
+                indices: FxHashSet::from_iter([0]),
             }
         );
     }

--- a/crates/auto-palette/src/image/segmentation/seed.rs
+++ b/crates/auto-palette/src/image/segmentation/seed.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 use crate::{math::Point, FloatNumber};
 
@@ -30,7 +30,7 @@ impl SeedGenerator {
         pixels: &[Point<T, N>],
         mask: &[bool],
         k: usize,
-    ) -> HashSet<usize>
+    ) -> FxHashSet<usize>
     where
         T: FloatNumber,
     {
@@ -41,11 +41,13 @@ impl SeedGenerator {
         );
 
         if k == 0 {
-            return HashSet::new();
+            return FxHashSet::default();
         }
 
         if k > pixels.len() {
-            return HashSet::from_iter(mask.iter().enumerate().filter(|(_, &m)| m).map(|(i, _)| i));
+            return FxHashSet::from_iter(
+                mask.iter().enumerate().filter(|(_, &m)| m).map(|(i, _)| i),
+            );
         }
 
         match self {
@@ -62,7 +64,7 @@ fn regular_grid<T, const N: usize>(
     pixels: &[Point<T, N>],
     mask: &[bool],
     k: usize,
-) -> HashSet<usize>
+) -> FxHashSet<usize>
 where
     T: FloatNumber,
 {
@@ -72,7 +74,7 @@ where
         .trunc_to_usize()
         .max(1); // Ensure step is at least 1
     let half = step / 2;
-    let mut seeds = HashSet::with_capacity(k);
+    let mut seeds = FxHashSet::with_capacity_and_hasher(k, Default::default());
     'outer: for y in (half..height).step_by(step) {
         for x in (half..width).step_by(step) {
             let index = x + y * width;
@@ -130,7 +132,7 @@ mod tests {
 
         // Assert
         assert_eq!(actual.len(), expected.len());
-        assert_eq!(actual, HashSet::from_iter(expected));
+        assert_eq!(actual, FxHashSet::from_iter(expected));
     }
 
     #[test]
@@ -181,6 +183,6 @@ mod tests {
 
         // Assert
         assert_eq!(actual.len(), 1);
-        assert_eq!(actual, HashSet::from_iter([7]));
+        assert_eq!(actual, FxHashSet::from_iter([7]));
     }
 }

--- a/crates/auto-palette/src/image/segmentation/segment.rs
+++ b/crates/auto-palette/src/image/segmentation/segment.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 use crate::{
     image::{Pixel, LABXY_CHANNELS},
@@ -21,7 +21,7 @@ where
     pub(super) center: Pixel<T>,
 
     /// The indices of the pixels that belong to this segment.
-    pub(super) indices: HashSet<usize>,
+    pub(super) indices: FxHashSet<usize>,
 }
 
 impl<T> SegmentMetadata<T>
@@ -40,7 +40,7 @@ where
         Self {
             label,
             center: [T::zero(); LABXY_CHANNELS],
-            indices: HashSet::new(),
+            indices: FxHashSet::default(),
         }
     }
 
@@ -149,6 +149,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
     use crate::assert_approx_eq;
 
@@ -163,7 +165,7 @@ mod tests {
             SegmentMetadata {
                 label: 0,
                 center: [0.0; LABXY_CHANNELS],
-                indices: HashSet::new(),
+                indices: FxHashSet::default(),
             }
         );
         assert!(actual.is_empty());

--- a/crates/auto-palette/src/image/segmentation/slic/algorithm.rs
+++ b/crates/auto-palette/src/image/segmentation/slic/algorithm.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::{
     image::{
@@ -120,7 +120,7 @@ where
         matrix: &MatrixView<'_, T, LABXY_CHANNELS>,
         pixels: &[Pixel<T>],
         mask: &[bool],
-        centers: &mut HashMap<usize, Pixel<T>>,
+        centers: &mut FxHashMap<usize, Pixel<T>>,
         builder: &mut SegmentBuilder<T>,
     ) -> bool {
         builder.iter_mut().for_each(SegmentMetadata::clear);
@@ -193,7 +193,7 @@ where
         let seeds = self
             .generator
             .generate(width, height, pixels, mask, self.segments);
-        let mut centers: HashMap<_, _> = seeds
+        let mut centers: FxHashMap<_, _> = seeds
             .into_iter()
             .map(|seed_index| {
                 let found = self.find_lowest_gradient_index(&matrix, seed_index, mask);

--- a/crates/auto-palette/src/palette.rs
+++ b/crates/auto-palette/src/palette.rs
@@ -1,4 +1,6 @@
-use std::{cmp::Reverse, collections::HashMap, marker::PhantomData};
+use std::{cmp::Reverse, marker::PhantomData};
+
+use rustc_hash::FxHashMap;
 
 use crate::{
     algorithm::Algorithm,
@@ -417,8 +419,8 @@ where
     let height = T::from_usize(label_image.height());
     let area = width * height;
 
-    let mut swatches = HashMap::new();
-    let mut populations = HashMap::new();
+    let mut swatches = FxHashMap::default();
+    let mut populations = FxHashMap::default();
     for (index, &label) in labels.iter().enumerate() {
         let Some(segment) = segments.get(index) else {
             continue;


### PR DESCRIPTION
## Description

In this pull request, replaced `HashMap` and `HashSet` with `FxHashMap` and `FxHashSet` to improve performance.   
The `FxHashMap` and `FxHashSet` are provided by the [`rustc-hash`](https://github.com/rust-lang/rustc-hash) crate, which uses a fast hashing algorithm.  
However, since the algorithm is not cryptographically secure, the usage is limited to internal library components.

## Related Issue

N/A

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
